### PR TITLE
Fixed date parsing for some imap servers

### DIFF
--- a/src/Ddeboer/Imap/Message/Headers.php
+++ b/src/Ddeboer/Imap/Message/Headers.php
@@ -27,6 +27,7 @@ class Headers
         }
 
         if (isset($this->array['date'])) {
+            $this->array['date'] = preg_replace('/(.*)\(.*\)/', '$1', $this->array['date']);
             $this->array['date'] = new \DateTime($this->array['date']);
         }
 


### PR DESCRIPTION
Sometimes the imap server write dates with the timezone as a string like "Fri, 11 Feb 2011 12:27:49 +0100 (Westeuropäische Normalzeit)". This fix removes the timezone string, otherwise `DateTime` throws an exception.
