### PR TITLE
Fixed bug in getDecodedContent with 'format=flowed' email

### DIFF
--- a/src/Ddeboer/Imap/Message/Part.php
+++ b/src/Ddeboer/Imap/Message/Part.php
@@ -136,7 +136,7 @@ class Part implements \RecursiveIterator
             $this->content = \imap_fetchbody(
                 $this->stream,
                 $this->messageNumber,
-                $this->partNumber
+                $this->partNumber ?: 1
             );
         }
 


### PR DESCRIPTION
With `Content-Type: text/plain; charset=ISO-8859-1; format=flowed` i got some a problem. 

There are no email `parts`, `partNumber` is null, so `Message::getBodyText()` fail back to `getDecodedContent()`, and the function get the whole email, including the header.

Using `1` as `partNumber` solved it.
