### PR TITLE
Support all IMAP message headers if needed. Remove Doctrine dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
     ],
     "require": {
         "ext-imap": "*",
-        "ext-mbstring": "*",
-        "doctrine/common": "*"
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "~3.7"

--- a/src/Ddeboer/Imap/Message.php
+++ b/src/Ddeboer/Imap/Message.php
@@ -175,11 +175,11 @@ class Message extends Message\Part
             // \imap_header returns only a subset of all mail headers,
             // but it does include the message flags.
 
-            if($rawHeaders) {
+            if ($rawHeaders) {
                 $rawHeaders = imap_fetchheader($this->stream, $message_number);
             }
 
-            $headers = \imap_header($this->stream, $message_number);
+            $headers = imap_header($this->stream, $message_number);
 
             // Would be useful if we weren't already calling imap_header()
             //$headers = imap_rfc822_parse_headers($rawHeaders);

--- a/src/Ddeboer/Imap/Message.php
+++ b/src/Ddeboer/Imap/Message.php
@@ -165,14 +165,27 @@ class Message extends Message\Part
      *
      * @return Message\Headers
      */
-    public function getHeaders()
+    public function getHeaders($rawHeaders = false)
     {
         if (null === $this->headers) {
+            
+            $message_number = imap_msgno($this->stream, $this->messageNumber);
+            
             // \imap_header is much faster than \imap_fetchheader
             // \imap_header returns only a subset of all mail headers,
             // but it does include the message flags.
-            $headers = \imap_header($this->stream, $this->messageNumber);
-            $this->headers = new Message\Headers($headers);
+
+            if($rawHeaders) {
+                $rawHeaders = imap_fetchheader($this->stream, $message_number);
+            }
+
+            $headers = \imap_header($this->stream, $message_number);
+
+            // Would be useful if we weren't already calling imap_header()
+            //$headers = imap_rfc822_parse_headers($rawHeaders);
+
+            $this->headers = new Message\Headers($headers, $rawHeaders ?: null);
+
         }
 
         return $this->headers;

--- a/src/Ddeboer/Imap/Message/Attachment.php
+++ b/src/Ddeboer/Imap/Message/Attachment.php
@@ -27,7 +27,9 @@ class Attachment extends Part
      */
     public function getFilename()
     {
-        return $this->parameters->get('filename');
+        if(isset($this->parameters['filename'])) {
+            return $this->parameters['filename'];
+        }
     }
 
     /**
@@ -37,6 +39,8 @@ class Attachment extends Part
      */
     public function getSize()
     {
-        return $this->parameters->get('size');
+        if(isset($this->parameters['size'])) {
+            return $this->parameters['size'];
+        }
     }
 }

--- a/src/Ddeboer/Imap/Message/Headers.php
+++ b/src/Ddeboer/Imap/Message/Headers.php
@@ -5,9 +5,12 @@ namespace Ddeboer\Imap\Message;
 class Headers
 {
     protected $array = array();
+    protected $rawHeaders = null;
 
-    public function __construct(\stdClass $headers)
+    public function __construct(\stdClass $headers, $rawHeaders = null)
     {
+        $this->rawHeaders = $rawHeaders;
+
         // Store all headers as lowercase
         $this->array = array_change_key_case((array) $headers);
 

--- a/src/Ddeboer/Imap/Message/Part.php
+++ b/src/Ddeboer/Imap/Message/Part.php
@@ -2,8 +2,6 @@
 
 namespace Ddeboer\Imap\Message;
 
-use Doctrine\Common\Collections\ArrayCollection;
-
 /**
  * A message part
  */
@@ -93,7 +91,9 @@ class Part implements \RecursiveIterator
 
     public function getCharset()
     {
-        return $this->parameters->get('charset');
+        if(isset($this->parameters['charset'])) {
+            return $this->parameters['charset'];
+        }
     }
 
     public function getType()
@@ -216,14 +216,15 @@ class Part implements \RecursiveIterator
             }
         }
 
-        $this->parameters = new ArrayCollection();
+
+        $this->parameters = array();
         foreach ($structure->parameters as $parameter) {
-            $this->parameters->set(strtolower($parameter->attribute), $parameter->value);
+            $this->parameters[strtolower($parameter->attribute)] = $parameter->value;
         }
 
         if (isset($structure->dparameters)) {
-            foreach ($structure->dparameters as $parameter) {
-                $this->parameters->set(strtolower($parameter->attribute), $parameter->value);
+            foreach ($structure->parameters as $parameter) {
+                $this->parameters[strtolower($parameter->attribute)] = $parameter->value;
             }
         }
 


### PR DESCRIPTION
(Background: I deal with a lot of messages which have custom headers.)

This commit solves two problems:
1. The Doctrine ArrayCollection object wastes resources in each message object for a simple MIME header array.
2. I need custom headers not returned by the default `imap_header()` function.
