### PR TITLE
Non-ASCII attachment filename decoding

### DIFF
--- a/src/Ddeboer/Imap/Message/Part.php
+++ b/src/Ddeboer/Imap/Message/Part.php
@@ -218,12 +218,12 @@ class Part implements \RecursiveIterator
 
         $this->parameters = new ArrayCollection();
         foreach ($structure->parameters as $parameter) {
-            $this->parameters->set(strtolower($parameter->attribute), $parameter->value);
+            $this->parameters->set(strtolower($parameter->attribute), $this->getParameterValue($parameter));
         }
 
         if (isset($structure->dparameters)) {
             foreach ($structure->dparameters as $parameter) {
-                $this->parameters->set(strtolower($parameter->attribute), $parameter->value);
+                $this->parameters->set(strtolower($parameter->attribute), $this->getParameterValue($parameter));
             }
         }
 
@@ -245,6 +245,17 @@ class Part implements \RecursiveIterator
                 }
             }
         }
+    }
+
+    private function getParameterValue($parameter)
+    {
+        $value = $parameter->value;
+        $value = \imap_utf8($value);
+        $value = \imap_mime_header_decode($value);
+        $value = \array_map(function ($value) { return $value->text; }, $value);
+        $value = \implode('', $value);
+
+        return $value;
     }
 
     /**


### PR DESCRIPTION
I had a problem downloading message parts with headers containing non-ASCII characters (attachment name/filename, to be exact).

Here is example part of received message:
```
--b1_21c078e69d0b21d50fd733085ceb8767
Content-Type: application/vnd.ms-excel; name="=?UTF-8?Q?Prost=C5=99eno=5F2014=5Fposledn=C3=AD_voln=C3=A9_term=C3=ADny.xls?="; charset="UTF-8"
Content-Transfer-Encoding: base64
Content-Disposition: attachment; filename="=?UTF-8?Q?Prost=C5=99eno=5F2014=5Fposledn=C3=AD_voln=C3=A9_term=C3=ADny.xls?="

0M8R4KGxGuEAAAAAAAAAAAAAAAAAAAAAPgADAP7/CQAGAAAAAAAAAAAAAAACAAAAwgAAAAAA
AAAAEAAA/v///wAAAAD+////AAAAAMAAAADBAAAA////////////////////////////////
...
```

This part gets decoded by ```imap_fetchstructure``` like this:
```php
stdClass Object(
    [type] => 3
    [encoding] => 3
    [ifsubtype] => 1
    [subtype] => VND.MS-EXCEL
    [ifdescription] => 0
    [ifid] => 0
    [bytes] => 137524
    [ifdisposition] => 1
    [disposition] => ATTACHMENT
    [ifdparameters] => 1
    [dparameters] => Array(
        [0] => stdClass Object(
            [attribute] => FILENAME
            [value] => =?ISO-8859-2?Q?Prost=F8eno=5F2014=5Fposledn=ED_voln=E9_term=EDny.xls?=
        )
    )

    [ifparameters] => 1
    [parameters] => Array(
        [0] => stdClass Object(
            [attribute] => CHARSET
            [value] => UTF-8
        )
        [1] => stdClass Object(
            [attribute] => NAME
            [value] => =?ISO-8859-2?Q?Prost=F8eno=5F2014=5Fposledn=ED_voln=E9_term=EDny.xls?=
        )
    )
)

```

To get the original value, I need to apply ```imap_utf8``` and ```imap_mime_header_decode``` functions. After that, a get the right filename ```Prostřeno_2014_poslední volné termíny.xls```.