### PR TITLE
Allow empty connection flags

### DIFF
--- a/src/Ddeboer/Imap/Server.php
+++ b/src/Ddeboer/Imap/Server.php
@@ -41,7 +41,7 @@ class Server
     {
         $this->hostname = $hostname;
         $this->port = $port;
-        $this->flags = '/'.ltrim($flags, '/');
+        $this->flags = $flags ? '/' . ltrim($flags, '/') : '';
     }
 
     /**


### PR DESCRIPTION
Allow server connection with no custom flags set.

The previous implementation always put at least the single leading slash and created an invalid connection string like `{imap.myhost.com:143/}`.
