### PR TITLE
Fix regex parsing the date header (allowing multiple brackets)

### DIFF
--- a/src/Ddeboer/Imap/Message/Headers.php
+++ b/src/Ddeboer/Imap/Message/Headers.php
@@ -29,7 +29,7 @@ class Headers
         }
 
         if (isset($this->array['date'])) {
-            $this->array['date'] = preg_replace('/(.*)\(.*\)/', '$1', $this->array['date']);
+            $this->array['date'] = preg_replace('/([^\(]*)\(.*\)/', '$1', $this->array['date']);
             $this->array['date'] = new \DateTime($this->array['date']);
         }
 


### PR DESCRIPTION
Sometimes we recive email with locally formated date header which can't be parsed using existing regex, because it contains multiple brackets.

Example header:

```
Fri, 13 Jun 2014 17:18:44 +0200 (Střední Evropa (letní čas))
```
