### PR TITLE
Utf-8 encode body content.

### DIFF
--- a/src/Ddeboer/Imap/Message/Part.php
+++ b/src/Ddeboer/Imap/Message/Part.php
@@ -154,7 +154,7 @@ class Part implements \RecursiveIterator
                     break;
 
                 case self::ENCODING_QUOTED_PRINTABLE:
-                    $this->decodedContent = \quoted_printable_decode($this->getContent());
+                    $this->decodedContent = \utf8_encode( \quoted_printable_decode($this->getContent()));
                     break;
 
                 case self::ENCODING_7BIT:


### PR DESCRIPTION
When trying to `$message->getBodyHtml()` on non-UTF-8 messages, I lost some characters:

ESPAÑA
became 
ESPAA

Adding  '\utf8_encode( \quoted_printable_decode($this->getContent()));' fixed it. 
