### PR TITLE
\imap_header dosen't work with UID

### DIFF
--- a/src/Ddeboer/Imap/Message.php
+++ b/src/Ddeboer/Imap/Message.php
@@ -171,7 +171,7 @@ class Message extends Message\Part
             // \imap_header is much faster than \imap_fetchheader
             // \imap_header returns only a subset of all mail headers,
             // but it does include the message flags.
-            $headers = \imap_header($this->stream, $this->messageNumber);
+            $headers = \imap_header($this->stream, \imap_msgno($this->stream, $this->messageNumber));
             $this->headers = new Message\Headers($headers);
         }
 


### PR DESCRIPTION
http://us1.php.net/manual/en/function.imap-header.php
http://us1.php.net/manual/en/function.imap-headerinfo.php

 msg_number
    The message number

http://us1.php.net/manual/en/function.imap-msgno.php
imap_msgno — Gets the message sequence number for the given UID

I don't know why PHP dosen't has a way to read the header with the UID but this is the solution.
