### PR TITLE
Allow binary-encoded part content

### DIFF
--- a/src/Ddeboer/Imap/Message/Part.php
+++ b/src/Ddeboer/Imap/Message/Part.php
@@ -159,6 +159,7 @@ class Part implements \RecursiveIterator
 
                 case self::ENCODING_7BIT:
                 case self::ENCODING_8BIT:
+                case self::ENCODING_BINARY:
                     $this->decodedContent = $this->getContent();
                     break;
 


### PR DESCRIPTION
From the e-mail MIME specification (RFC 2045):

> The Content-Transfer-Encoding values "7bit", "8bit", and "binary" all
>    mean that the identity (i.e. NO) encoding transformation has been
>    performed.
