### PR TITLE
Handling attachments when part parameters include filename or name

### DIFF
--- a/src/Ddeboer/Imap/Message/Part.php
+++ b/src/Ddeboer/Imap/Message/Part.php
@@ -236,13 +236,20 @@ class Part implements \RecursiveIterator
                     $partNumber = (string) ($this->partNumber . '.' . ($key+1));
                 }
 
-                if (isset($partStructure->disposition)
+	            $partParameters = new ArrayCollection();
+	            foreach ($partStructure->parameters as $partParameter) {
+		            $partParameters->set(strtolower($partParameter->attribute), $partParameter->value);
+	            }
+
+                if ((isset($partStructure->disposition)
                     && (strtolower($partStructure->disposition) == 'attachment'
                         || strtolower($partStructure->disposition) == 'inline')
-                    && strtoupper($partStructure->subtype) != "PLAIN"
+                    && strtoupper($partStructure->subtype) != "PLAIN")
+                    || $partParameters->containsKey('name')
+                    || $partParameters->containsKey('filename')
                 ) {
-                    $attachment = new Attachment($this->stream, $this->messageNumber, $partNumber, $partStructure);
-                    $this->parts[] = $attachment;
+	                $attachment    = new Attachment( $this->stream, $this->messageNumber, $partNumber, $partStructure );
+	                $this->parts[] = $attachment;
                 } else {
                     $this->parts[] = new Part($this->stream, $this->messageNumber, $partNumber, $partStructure);
                 }


### PR DESCRIPTION
This is my first PR... I hope it's done right!

The problem: some attachments didn't have the ifdisposition=1 within the part structure, so the original code missed them.

The solution: I grab the part parameters and check if the 'name' or 'filename' properties exist, indicating a file attachment.

PhpStorm changed some formatting which shows up in the diff...
