### PR TITLE
Better check for attachments

### DIFF
--- a/src/Ddeboer/Imap/Message/Part.php
+++ b/src/Ddeboer/Imap/Message/Part.php
@@ -236,17 +236,22 @@ class Part implements \RecursiveIterator
                     $partNumber = (string) ($this->partNumber . '.' . ($key+1));
                 }
 
-	            $partParameters = new ArrayCollection();
-	            foreach ($partStructure->parameters as $partParameter) {
-		            $partParameters->set(strtolower($partParameter->attribute), $partParameter->value);
+	            // Special case for attachments ?
+	            $attachmentFoundByFilename = false;
+	            if (isset($partStructure->ifparameters) && $partStructure->ifparameters === 1) {
+		            foreach($partStructure->parameters as $partParameter) {
+			            if (strtolower($partParameter->attribute) === 'name' || strtolower($partParameter->attribute) === 'filename') {
+				            $attachmentFoundByFilename = true;
+				            break 1; // No need to go on after we've found what we were looking for
+			            }
+		            }
 	            }
 
                 if ((isset($partStructure->disposition)
                     && (strtolower($partStructure->disposition) == 'attachment'
                         || strtolower($partStructure->disposition) == 'inline')
                     && strtoupper($partStructure->subtype) != "PLAIN")
-                    || $partParameters->containsKey('name')
-                    || $partParameters->containsKey('filename')
+                    || $attachmentFoundByFilename
                 ) {
 	                $attachment = new Attachment($this->stream, $this->messageNumber, $partNumber, $partStructure);
 	                $this->parts[] = $attachment;

--- a/src/Ddeboer/Imap/Message/Part.php
+++ b/src/Ddeboer/Imap/Message/Part.php
@@ -250,7 +250,7 @@ class Part implements \RecursiveIterator
                 if ((isset($partStructure->disposition)
                     && (strtolower($partStructure->disposition) == 'attachment'
                         || strtolower($partStructure->disposition) == 'inline')
-                    && strtoupper($partStructure->subtype) != "PLAIN")
+                    && strtoupper($partStructure->subtype) != 'PLAIN')
                     || $attachmentFoundByFilename
                 ) {
 	                $attachment = new Attachment($this->stream, $this->messageNumber, $partNumber, $partStructure);

--- a/src/Ddeboer/Imap/Message/Part.php
+++ b/src/Ddeboer/Imap/Message/Part.php
@@ -248,7 +248,7 @@ class Part implements \RecursiveIterator
                     || $partParameters->containsKey('name')
                     || $partParameters->containsKey('filename')
                 ) {
-	                $attachment    = new Attachment( $this->stream, $this->messageNumber, $partNumber, $partStructure );
+	                $attachment = new Attachment($this->stream, $this->messageNumber, $partNumber, $partStructure);
 	                $this->parts[] = $attachment;
                 } else {
                     $this->parts[] = new Part($this->stream, $this->messageNumber, $partNumber, $partStructure);


### PR DESCRIPTION
Fixes #55.  This is a new PR to fix the referenced issue.  My original code used an ArrayCollection which seemed like overkill for the problem at hand.

This new approach simply iterates over the part parameters and if the attributes 'name' or 'filename' are found, iteration stops and the flag is set to true.