### PR TITLE
FIX: PHP error: "Cannot declare class Ddeboer\Imap\Search\Text\Text ..."

### DIFF
--- a/src/Ddeboer/Imap/Search/Text/Text.php
+++ b/src/Ddeboer/Imap/Search/Text/Text.php
@@ -2,13 +2,13 @@
 
 namespace Ddeboer\Imap\Search\Text;
 
-use Ddeboer\Imap\Search\Text;
+use Ddeboer\Imap\Search\Text as SearchText;
 
 /**
  * Represents a message text contains condition. Messages must contain the
  * specified text in order to match the condition.
  */
-class Text extends Text
+class Text extends SearchText
 {
     /**
      * Returns the keyword that the condition represents.


### PR DESCRIPTION
FIX: PHP error: "Cannot declare class Ddeboer\Imap\Search\Text\Text because the name is already in use"