### PR TITLE
Make sure imap connection are reopened

### DIFF
--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -136,7 +136,7 @@ class Mailbox implements \IteratorAggregate
     private function init()
     {
         $check = imap_check($this->connection->getResource());
-        if ($check->Mailbox != $this->mailbox) {
+        if ($check === false || $check->Mailbox != $this->mailbox) {
             imap_reopen($this->connection->getResource(), $this->mailbox);
         }
     }


### PR DESCRIPTION
If you leave the connection open, for example in a cli script, the `imap_check` returns false sometimes. This makes sure the connection are reopened.