### PR TITLE
Added hasMailbox to Connection

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -50,6 +50,18 @@ class Connection
     }
 
     /**
+     * Check that a mailbox with the given name exists
+     *
+     * @param string $name Mailbox name
+     *
+     * @return bool
+     */
+    public function hasMailbox($name)
+    {
+        return in_array($name, $this->getMailboxNames());
+    }
+
+    /**
      * Get a mailbox by its name
      *
      * @param string $name Mailbox name
@@ -59,7 +71,7 @@ class Connection
      */
     public function getMailbox($name)
     {
-        if (!in_array($name, $this->getMailboxNames())) {
+        if (!$this->hasMailbox($name)) {
             throw new MailboxDoesNotExistException($name);
         }
 


### PR DESCRIPTION
This PR adds a public `hasMailbox` to the Connection making it easier for a user to check if a box exists and avoids a try catch that is not needed.