### PR TITLE
Implement "undisclosed recipients" addresses

### DIFF
--- a/src/Message/Headers.php
+++ b/src/Message/Headers.php
@@ -74,8 +74,13 @@ class Headers extends Parameters
 
     private function decodeEmailAddress($value)
     {
+        if(!isset($value->mailbox)){
+            $mailbox = 'undisclosed';
+        } else {
+            $mailbox = $value->mailbox;
+        }
         return new EmailAddress(
-            $value->mailbox,
+            $mailbox,
             isset($value->host) ? $value->host : null,
             isset($value->personal) ? $this->decode($value->personal) : null
         );


### PR DESCRIPTION
I keep getting an error when the email doesn't have the to: value for some reason, so this helps to prevent the exception.
