### PR TITLE
Return body of single-part HTML message as HTML, not text

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -201,6 +201,13 @@ class Message extends Message\Part
                 return $part->getDecodedContent($this->keepUnseen);
             }
         }
+
+        // If message has no parts and is HTML, return content of message itself.
+        if ($this->getSubtype() == 'HTML') {
+            return $this->getDecodedContent($this->keepUnseen);
+        }
+
+        return null;
     }
 
     /**
@@ -218,7 +225,11 @@ class Message extends Message\Part
         }
 
         // If message has no parts, return content of message itself.
-        return $this->getDecodedContent($this->keepUnseen);
+        if ($this->getSubtype() != 'HTML') {
+            return $this->getDecodedContent($this->keepUnseen);
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
Return content of single-part message in `$message->getHtmlBody()` when content type of message is HTML.
