### PR TITLE
Fallback to available decodedContent on UndetectableEncodingException

### DIFF
--- a/src/Message/Part.php
+++ b/src/Message/Part.php
@@ -4,6 +4,7 @@ namespace Ddeboer\Imap\Message;
 
 use Ddeboer\Imap\Parameters;
 use Ddeboer\Transcoder\Transcoder;
+use Ddeboer\Transcoder\Exception\UndetectableEncodingException;
 
 /**
  * A message part
@@ -182,10 +183,18 @@ class Part implements \RecursiveIterator
             if ($this->getType() === self::TYPE_TEXT
                 && strtolower($this->getCharset()) != 'utf-8'
             ) {
-                $this->decodedContent = Transcoder::create()->transcode(
-                    $this->decodedContent,
-                    $this->getCharset()
-                );
+                try
+                {
+                    $transcoded = Transcoder::create()->transcode(
+                        $this->decodedContent,
+                        $this->getCharset()
+                    );
+                    $this->decodedContent = $transcoded;
+                }
+                catch (UndetectableEncodingException $e)
+                {
+                    // fallback to decodedContent, without transcode
+                }
             }
         }
 


### PR DESCRIPTION
On calling `getDecodedContent` with an attachment detected as `TYPE_TEXT` and a charset not `utf-8`, Transcoder turns in action, to decode the content.

In my case, Transcoder throws the exception `UndetectableEncodingException`:

```
Encoding for <html>
<body style="word-wrap: break-word; -webkit-nbsp-mode: space; -webkit-line-break: after-white-space;">
<head>
<base href="x-msg://103/">
</head>
<div class="AppleOriginalContents">
<blockquote type="cite">
<span class="Apple-style-span" style="border-collapse: separate; font-family: Helvetica; font-style: normal; font-variant: normal; font-weight: normal; letter-spacing: normal; line-height: normal; orphans: 2; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-border-horizontal-spacing: 0px; -webkit-border-vertical-spacing: 0px; -webkit-text-decorations-in-effect: none; -webkit-text-size-adjust: auto; -webkit-text-stroke-width: 0px; font-size: medium;">
<div bgcolor="white" lang="DE" link="blue" vlink="purple">
<div class="WordSection1" style="page: WordSection1;">
<div>
<div style="margin-top: 0cm; margin-right: 0cm; margin-bottom: 0.0001pt; margin-left: 0cm; font-size: 12pt; font-family: 'Times New Roman', serif;">
<span style="font-size: 8pt; font-family: Calibri, sans-serif; color: rgb(31, 73, 125); text-decoration: none; ">
</span>
<span style="font-size: 8pt; font-family: Calibri, sans-serif; color: rgb(31, 73, 125); ">
<br>
</span>
<span style="font-size: 8pt; font-family: Calibri, sans-serif; color: rgb(51, 51, 51); ">
Bitte informieren Sie den Absender, sofern Sie nicht der richtige Adressat sind und<span class="Apple-converted-space">
&nbsp;</span>
<br>
l�schen diese E-Mail, die vertrauliche Informationen enthalten kann, vielen Dank.<br>
Please contact the sender, if you are not the recipient and delete this email,<span class="Apple-converted-space">
&nbsp;</span>
<br>
which may contain confidential and/or privileged information, thank you.<br>
<br>
<br>
<br>
</span>
<span style="font-size: 5pt; font-family: Calibri, sans-serif; color: rgb(51, 51, 51); ">
<o:p>
</o:p>
</span>
</div>
<div style="margin-top: 0cm; margin-right:  0cm; margin-bottom: 0.0001pt; margin-left: 0cm; font-size: 12pt; font-family: 'Times New Roman', serif; ">
<span style="font-size: 8pt; font-family: Calibri, sans-serif; color: rgb(31, 73, 125); ">
<o:p>
&nbsp;</o:p>
</span>
</div>
</div>
<div style="margin-top: 0cm; margin-right: 0cm; margin-bottom: 0.0001pt; margin-left: 0cm; font-size: 12pt; font-family: 'Times New Roman', serif; ">
<span style="font-size: 11pt; font-family: Calibri, sans-serif; color: rgb(31, 73, 125); ">
<o:p>
&nbsp;</o:p>
</span>
</div>
<div>
<div style="border-right-style: none; border-bottom-style: none; border-left-style: none; border-width: initial; border-color: initial; border-top-style: solid; border-top-color: rgb(181, 196, 223); border-top-width: 1pt; padding-top: 3pt; padding-right: 0cm; padding-bottom: 0cm; padding-left: 0cm; ">
</body>
</html>
 is undetectable: mb_convert_encoding(): Unable to detect character encoding
```

I think it would be better to response with the available decodedContent, than with nothing, wouldn't it?