### PR TITLE
Remove set_error_handler, use @imap_* instead

### DIFF
--- a/src/Exception/MessageDoesNotExistException.php
+++ b/src/Exception/MessageDoesNotExistException.php
@@ -4,13 +4,12 @@ namespace Ddeboer\Imap\Exception;
 
 class MessageDoesNotExistException extends Exception
 {
-    public function __construct($number, $error)
+    public function __construct($number)
     {
         parent::__construct(
             sprintf(
-                'Message %s does not exist: %s',
-                $number,
-                $error
+                'Message %s does not exist',
+                $number
             )
         );
     }

--- a/src/Message.php
+++ b/src/Message.php
@@ -309,22 +309,15 @@ class Message extends Message\Part
      */
     private function loadStructure()
     {
-        set_error_handler(
-            function ($nr, $error) {
-                throw new MessageDoesNotExistException(
-                    $this->messageNumber,
-                    $error
-                );
-            }
-        );
-
-        $structure = imap_fetchstructure(
+        $structure = @imap_fetchstructure(
             $this->stream,
             $this->messageNumber,
             \FT_UID
         );
 
-        restore_error_handler();
+        if (!$structure) {
+            throw new MessageDoesNotExistException($this->messageNumber);
+        }
 
         $this->parseStructure($structure);
     }

--- a/src/Server.php
+++ b/src/Server.php
@@ -70,14 +70,7 @@ class Server
      */
     public function authenticate($username, $password)
     {
-        // Wrap imap_open, which gives notices instead of exceptions
-        set_error_handler(
-            function ($nr, $message) use ($username) {
-                throw new AuthenticationFailedException($username, $message);
-            }
-        );
-        
-        $resource = imap_open(
+        $resource = @imap_open(
             $this->getServerString(),
             $username,
             $password,
@@ -89,8 +82,6 @@ class Server
         if (false === $resource) {
             throw new AuthenticationFailedException($username);
         }
-        
-        restore_error_handler();
 
         $check = imap_check($resource);
         $mailbox = $check->Mailbox;


### PR DESCRIPTION
Hi.

This fix will use `@` instead of `set_error_handler`.
Why I did it? With `set_error_handler` I can't catch MessageDoesNotExistException or AuthenticationFailedException in symfony2 application.

Here is example how symfony developers decided the same issue: 
https://github.com/symfony/symfony/blob/2.8/src/Symfony/Component/HttpFoundation/File/File.php#L96
