### PR TITLE
use imap_fetchheader and imap_rfc822_parser_headers as fallback to receive from-header

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -182,6 +182,16 @@ class Message extends Message\Part
             // imap_header returns only a subset of all mail headers,
             // but it does include the message flags.
             $headers = imap_header($this->stream, imap_msgno($this->stream, $this->messageNumber));
+
+            // if from isn't included in headers, yet, try to use imap_fetchheader and imap_rfc822_parse_headers
+            if (isset($headers->from) == false)
+            {
+                $rawHeader = imap_rfc822_parse_headers(imap_fetchheader($this->stream, imap_msgno($this->stream, $this->messageNumber)));
+
+                if (isset($rawHeader->from))
+                    $headers->from = $rawHeader->from;
+            }
+
             $this->headers = new Message\Headers($headers);
         }
 


### PR DESCRIPTION
sometimes `imap_header` can't fetch the `from`-header (i.e. if utf-8 characters are included).

For example:

raw header from `imap_fetchheader`:

```
Return-Path: <message@mailserver.com>
Received: from cluster.server.com ([xxx.xxx.xxx.xxx]) by mail.server.com
 (mouse [xxx.xxx.xxx.xxx]) with ESMTP (Nemesis) id 0MeRa7-1cLBGo0sQx-00QBRx
 for <test@example.com>; Fri, 14 Oct 2016 12:25:13 +0200
From: \"Universit\u00e4t Hamburg Marketing GmbH \" <message@mailserver.com>
Reply-To: info@mailserver.com
To: test@example.com
Subject: =?UTF-8?B?U3RlbGxlbndlcmstUmVjaG51bmcgMTYxMDExNDkgdm9tIDEzLjEwLjIw?=
\t=?UTF-8?B?MTY=?=
Date: Fri, 14 Oct 2016 10:25:13 GMT
MIME-Version: 1.0
Content-Type: multipart\/mixed;
\tboundary=\"-XimantiXSemanticMail\"
Envelope-To: <test@example.com>
X-UI-Filterresults: notjunk:1;V01:K0:1xdSVlc\/UH8=:MNtO5wvX\/NvFYa5\/e7Hvl3YCqp
 7AMD4ip7bykcH5vo400n+cv1q3ifL1UbzTHiF3hdyHJRWOfJD+5erji8LTJDz5DJ4DAVc99vh
 xpneIPRB8PofnNJ336iwwuGDMohzze5Z3LuIz11UUUZP8\/Gr8WwR1nXLBizAOuooxp0n7WiOY
 b4Jvt40nOiCe5nSISg6CsEVGHYA8Og7pjIeCejfbd43NKFf79QfGOVZi+zNrz94wCqIph1qUj
 GoOFWWC9VM+uCBim7mQ8wGCCMgP2X9qmy7ZbLgY1rOK7wQ9bXbHR0CiMuNHdpJag24e4Zd1rA
 aWtfOhjr07YOb23en0x1BBlh9fB0JIcmvirbZMuoP18Ft8vmP\/hncv7IeUyU\/6dLFXyPRMmqW
 ri98cn7LG4aiKugnRx+lISqHBiyh0ekCccmnBvVBCRZBytzQ9HQdQjG2U7qFdmijqBsGmuBx4
 zmQUmt2zA2kFeqA71BxFqakDC8lEf3rwTDFVOXG5MqJ1LkT\/1\/AzTzdE6xcEafm3Ms3eO5oPK
 Z2yx12YpYUBo37eL4UBbq9WuOaUkKhN2\/e0Ev1be9e0NylFRnXm+Nd0HPZulia5gz6TByBTSN
 Yr8I38d74\/TjZqkuFeB6adsNprAE\/8a\/+y5tfrUuAU+zSd+HOh457uUFSDhisxVFL4Eb9p9gt
 jh4w4oU1zGYZisc4Ks5Op05a6pNaCfmfRcMWF2W\/zXSu\/mfTs9aBxMFEFpYapN+GqqRUoBwJq
 QjvY7+t3Hw+erYvXs3BWvgFx6FadFzunf1yXKaclgm4dUoy3Knt5iaWwaGE3+JgsxmeJwdYHU
 5ZqpVeC+bTyMFjE06KLcSqeEJQB1wMEsGvIdVMudelOz9o+VAp5YZtVsaDKzU73N5hZj+jX\/n
 L0JuMfGL3B4SP4LkaCNIqVeC5iS62e807RXC19IfJopRvKfiMbHfp6Mf+1pn2PVTkC1gIUm9B
 FWbqn61byd4T2N3Q\/H3x\/JyJU83mZI2CagQPzJcnHpbtJ9KnPaze0yLV4ZG1qyW5FJnFEsuyj
 XvG2rCZUPD39NnaBqGKMfvzriUeLJFqdnMAOvhxa0tQccZQfoYsUgR2K9monybbVWpaJ+ttH5
 o8vzOqMPiR1Kb5Wy5L37nOPpheDrfUo4uzM+X9Ki+y\/iWKizXeD0SK77QTHL7mu+0m\/FWd5fY
 80a6t9+xB9clwJgTnVlA9b0NssgWmp2xsQGSNk7fid3NkvolsBzoVsehaJ208Rr3qlW5xKOtF
 SDRnjYwk1jmg3uCV2aUD51R6LvZm+uB5kKfaZ3n9+Xd3NfFNpQeIz2aCkDl6dMM2B5QHEEgCt
 efjXKMbZTdmzKmjcU5ivGPXVvg==
```

parsed header by `imap_header`:

```
{  
   "date":"Fri, 14 Oct 2016 10:24:57 GMT",
   "Date":"Fri, 14 Oct 2016 10:24:57 GMT",
   "subject":"=?UTF-8?B?U3RlbGxlbndlcmstUmVjaG51bmcgMTYxMDExNDUgdm9tIDEzLjEwLjIw?=\t=?UTF-8?B?MTY=?=",
   "Subject":"=?UTF-8?B?U3RlbGxlbndlcmstUmVjaG51bmcgMTYxMDExNDUgdm9tIDEzLjEwLjIw?=\t=?UTF-8?B?MTY=?=",
   "toaddress":"test@example.com",
   "to":[  
      {  
         "mailbox":"test",
         "host":"example.com"
      }
   ],
   "reply_toaddress":"info@mailserver.com",
   "reply_to":[  
      {  
         "mailbox":"info",
         "host":"mailserver.com"
      }
   ],
   "Recent":" ",
   "Unseen":" ",
   "Flagged":" ",
   "Answered":" ",
   "Deleted":" ",
   "Draft":" ",
   "Msgno":"   2",
   "MailDate":"14-Oct-2016 10:24:58 +0000",
   "Size":"94110",
   "udate":1476440698
}
```

I've added a fallback with the combination of `imap_fetchheader` and `imap_rfc822_parse_headers`, which will properly set the `from`-header:

```
{  
   "date":"Fri, 14 Oct 2016 10:24:57 GMT",
   "Date":"Fri, 14 Oct 2016 10:24:57 GMT",
   "subject":"=?UTF-8?B?U3RlbGxlbndlcmstUmVjaG51bmcgMTYxMDExNDUgdm9tIDEzLjEwLjIw?=\t=?UTF-8?B?MTY=?=",
   "Subject":"=?UTF-8?B?U3RlbGxlbndlcmstUmVjaG51bmcgMTYxMDExNDUgdm9tIDEzLjEwLjIw?=\t=?UTF-8?B?MTY=?=",
   "toaddress":"test@example.com",
   "to":[  
      {  
         "mailbox":"test",
         "host":"example.com"
      }
   ],
   "reply_toaddress":"info@mailserver.com",
   "reply_to":[  
      {  
         "mailbox":"info",
         "host":"mailserver.com"
      }
   ],
   "Recent":" ",
   "Unseen":" ",
   "Flagged":" ",
   "Answered":" ",
   "Deleted":" ",
   "Draft":" ",
   "Msgno":"   2",
   "MailDate":"14-Oct-2016 10:24:58 +0000",
   "Size":"94110",
   "udate":1476440698,
   "from":[  
      {  
         "personal":"Universit\u00e4t Hamburg Marketing GmbH ",
         "mailbox":"message",
         "host":"mailserver.com"
      }
   ],
}
```
