### PR TITLE
Handling emails that are the attachment itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ is installed. For instance on Debian:
 The recommended way to install the IMAP library is through [Composer](http://getcomposer.org):
 
 ```bash
-$ composer require ddeboer/imap
+$ composer require pedrofornaza/imap
 ```
 
 This command requires you to have Composer installed globally, as explained

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ddeboer/imap",
+    "name": "pedrofornaza/imap",
     "description": "Object-oriented IMAP for PHP",
     "keywords": [ "email", "mail", "imap" ],
     "license": "MIT",
@@ -11,7 +11,7 @@
         {
             "name": "Community contributors",
             "homepage": "https://github.com/ddeboer/imap/graphs/contributors"
-        }   
+        }
     ],
     "require": {
         "php": ">=5.4.0",

--- a/src/Message/Part.php
+++ b/src/Message/Part.php
@@ -240,6 +240,14 @@ class Part implements \RecursiveIterator
             $this->parameters->add($structure->dparameters);
         }
 
+        // When the message is not multipart and the body is the attachment content
+        if (isset($structure->disposition) &&
+            strtolower($structure->disposition) == 'attachment' &&
+          ! ($this instanceof Attachment) // Prevents infinite recursion
+        ) {
+            $this->parts[] = new Attachment($this->stream, $this->messageNumber, 1, $structure);
+        }
+
         if (isset($structure->parts)) {
             foreach ($structure->parts as $key => $partStructure) {
                 if (null === $this->partNumber) {


### PR DESCRIPTION
Hello!

I've had some cases that the emails has no content. The body itself is the content of attachment already.

Since they are business emails, i cant provide you a full example, but the emails looks like this:

`Subject: XXXXXX
MIME-Version: 1.0
Content-Type: application/octet-stream; name=XXXX.txt
Content-Transfer-Encoding: base64
Content-Disposition: attachment; filename=XXXXXX.txt

base64content==...`