### PR TITLE
Catch imap_fetchstructure empty result

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -323,6 +323,8 @@ class Message extends Message\Part
             $this->messageNumber,
             \FT_UID
         );
+
+        restore_error_handler();
         
         if (!$structure) {
             throw new MessageDoesNotExistException(
@@ -330,8 +332,6 @@ class Message extends Message\Part
                 "imap_fetchstructure returned empty message"
             );
         }
-
-        restore_error_handler();
 
         $this->parseStructure($structure);
     }

--- a/src/Message.php
+++ b/src/Message.php
@@ -323,6 +323,13 @@ class Message extends Message\Part
             $this->messageNumber,
             \FT_UID
         );
+        
+        if (!$structure) {
+            throw new MessageDoesNotExistException(
+                $this->messageNumber,
+                "imap_fetchstructure returned empty message"
+            );
+        }
 
         restore_error_handler();
 


### PR DESCRIPTION
`imap_fetchstructure` can [return false on error](http://php.net/manual/en/function.imap-fetchstructure.php#116898). For me, this is generating a Fatal PHP error because a boolean (`false`) is being passed to `parseStructure` which requires a `stdClass` for the first argument.