### PR TITLE
Special characters bug fixed!

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -57,7 +57,7 @@ class Connection
      * @return bool
      */
     public function hasMailbox($name)
-    {
+    {   
         return in_array($name, $this->getMailboxNames());
     }
 
@@ -75,7 +75,7 @@ class Connection
             throw new MailboxDoesNotExistException($name);
         }
 
-        return new Mailbox($this->server . imap_utf7_encode($name), $this);
+        return new Mailbox($this->server . mb_convert_encoding($name, 'UTF7-IMAP'), $this);
     }
 
     /**
@@ -151,7 +151,7 @@ class Connection
         if (null === $this->mailboxNames) {
             $mailboxes = imap_getmailboxes($this->resource, $this->server, '*');
             foreach ($mailboxes as $mailbox) {
-                $this->mailboxNames[] = imap_utf7_decode(str_replace($this->server, '', $mailbox->name));
+                $this->mailboxNames[] = str_replace($this->server, '', mb_convert_encoding($mailbox->name, 'UTF-8', 'UTF7-IMAP'));
             }
         }
 


### PR DESCRIPTION
getMailbox function was wrong working on folder names with special characters. 
Example folder name: "Fıstıkçı Şahap".