### PR TITLE
Exception: increase verbosity with imap_alerts() and imap_errors()

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -75,7 +75,10 @@ class Connection
     public function getMailbox($name)
     {
         if (!$this->hasMailbox($name)) {
-            throw new MailboxDoesNotExistException($name);
+            throw new MailboxDoesNotExistException(sprintf(
+                'Mailbox "%s" does not exist',
+                $name
+            ));
         }
 
         return new Mailbox($this->server . imap_utf7_encode($name), $this);

--- a/src/Exception/AuthenticationFailedException.php
+++ b/src/Exception/AuthenticationFailedException.php
@@ -4,16 +4,6 @@ declare(strict_types=1);
 
 namespace Ddeboer\Imap\Exception;
 
-class AuthenticationFailedException extends Exception
+final class AuthenticationFailedException extends Exception
 {
-    public function __construct($user, $error = null)
-    {
-        parent::__construct(
-            sprintf(
-                'Authentication failed for user %s with error %s',
-                $user,
-                $error
-            )
-        );
-    }
 }

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -35,7 +35,7 @@ class Exception extends \RuntimeException
         $alerts = imap_alerts();
         $errors = imap_errors();
         $completeMessage = sprintf(
-            "%s%s\nAlerts (%s):%s\nErrors (%s):%s",
+            "%s%s\nimap_alerts (%s):%s\nimap_errors (%s):%s",
             $errorType,
             $message,
             $alerts ? count($alerts) : 0,

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -6,21 +6,44 @@ namespace Ddeboer\Imap\Exception;
 
 class Exception extends \RuntimeException
 {
-    protected $errors = [];
+    private static $errorLabels = [
+        E_ERROR => 'E_ERROR',
+        E_WARNING => 'E_WARNING',
+        E_PARSE => 'E_PARSE',
+        E_NOTICE => 'E_NOTICE',
+        E_CORE_ERROR => 'E_CORE_ERROR',
+        E_CORE_WARNING => 'E_CORE_WARNING',
+        E_COMPILE_ERROR => 'E_COMPILE_ERROR',
+        E_COMPILE_WARNING => 'E_COMPILE_WARNING',
+        E_USER_ERROR => 'E_USER_ERROR',
+        E_USER_WARNING => 'E_USER_WARNING',
+        E_USER_NOTICE => 'E_USER_NOTICE',
+        E_STRICT => 'E_STRICT',
+        E_RECOVERABLE_ERROR => 'E_RECOVERABLE_ERROR',
+        E_DEPRECATED => 'E_DEPRECATED',
+        E_USER_DEPRECATED => 'E_USER_DEPRECATED',
+    ];
 
-    public function __construct($message, $code = 0, $previous = null)
+    final public function __construct($message, $code = 0, $previous = null)
     {
-        parent::__construct($message, $code, $previous);
-        $this->errors = imap_errors();
-    }
+        $errorType = '';
+        if (is_int($code) && isset(self::$errorLabels[$code])) {
+            $errorType = sprintf('[%s] ', self::$errorLabels[$code]);
+        }
 
-    /**
-     * Get IMAP errors
-     *
-     * @return array
-     */
-    public function getErrors()
-    {
-        return $this->errors;
+        $joinString = "\n- ";
+        $alerts = imap_alerts();
+        $errors = imap_errors();
+        $completeMessage = sprintf(
+            "%s%s\nAlerts (%s):%s\nErrors (%s):%s",
+            $errorType,
+            $message,
+            $alerts ? count($alerts) : 0,
+            $alerts ? $joinString . implode($joinString, $alerts) : '',
+            $errors ? count($errors) : 0,
+            $errors ? $joinString . implode($joinString, $errors) : ''
+        );
+
+        parent::__construct($completeMessage, $code, $previous);
     }
 }

--- a/src/Exception/MailboxDoesNotExistException.php
+++ b/src/Exception/MailboxDoesNotExistException.php
@@ -4,10 +4,6 @@ declare(strict_types=1);
 
 namespace Ddeboer\Imap\Exception;
 
-class MailboxDoesNotExistException extends Exception
+final class MailboxDoesNotExistException extends Exception
 {
-    public function __construct($mailbox)
-    {
-        parent::__construct('Mailbox ' . $mailbox . ' does not exist');
-    }
 }

--- a/src/Exception/MessageDeleteException.php
+++ b/src/Exception/MessageDeleteException.php
@@ -4,10 +4,6 @@ declare(strict_types=1);
 
 namespace Ddeboer\Imap\Exception;
 
-class MessageDeleteException extends Exception
+final class MessageDeleteException extends Exception
 {
-    public function __construct($messageNumber)
-    {
-        parent::__construct(sprintf('Message %s cannot be deleted', $messageNumber));
-    }
 }

--- a/src/Exception/MessageDoesNotExistException.php
+++ b/src/Exception/MessageDoesNotExistException.php
@@ -4,16 +4,6 @@ declare(strict_types=1);
 
 namespace Ddeboer\Imap\Exception;
 
-class MessageDoesNotExistException extends Exception
+final class MessageDoesNotExistException extends Exception
 {
-    public function __construct($number, $error)
-    {
-        parent::__construct(
-            sprintf(
-                'Message %s does not exist: %s',
-                $number,
-                $error
-            )
-        );
-    }
 }

--- a/src/Exception/MessageMoveException.php
+++ b/src/Exception/MessageMoveException.php
@@ -4,16 +4,6 @@ declare(strict_types=1);
 
 namespace Ddeboer\Imap\Exception;
 
-class MessageMoveException extends Exception
+final class MessageMoveException extends Exception
 {
-    public function __construct($messageNumber, $mailbox)
-    {
-        parent::__construct(
-            sprintf(
-                'Message %s cannot be moved to %s',
-                $messageNumber,
-                $mailbox
-            )
-        );
-    }
 }

--- a/src/Message.php
+++ b/src/Message.php
@@ -275,7 +275,10 @@ class Message extends Message\Part
         $this->headers = null;
 
         if (!imap_delete($this->stream, $this->messageNumber, \FT_UID)) {
-            throw new MessageDeleteException($this->messageNumber);
+            throw new MessageDeleteException(sprintf(
+                'Message "%s" cannot be deleted',
+                $this->messageNumber
+            ));
         }
     }
 
@@ -291,7 +294,11 @@ class Message extends Message\Part
     public function move(Mailbox $mailbox)
     {
         if (!imap_mail_move($this->stream, $this->messageNumber, $mailbox->getName(), \CP_UID)) {
-            throw new MessageMoveException($this->messageNumber, $mailbox->getName());
+            throw new MessageMoveException(sprintf(
+                'Message "%s" cannot be moved to "%s"',
+                $this->messageNumber,
+                $mailbox->getName()
+            ));
         }
 
         return $this;
@@ -318,14 +325,13 @@ class Message extends Message\Part
      */
     private function loadStructure()
     {
-        set_error_handler(
-            function ($nr, $error) {
-                throw new MessageDoesNotExistException(
-                    $this->messageNumber,
-                    $error
-                );
-            }
-        );
+        set_error_handler(function ($nr, $error) {
+            throw new MessageDoesNotExistException(sprintf(
+                'Message %s does not exist: %s',
+                $this->messageNumber,
+                $error
+            ), $nr);
+        });
 
         $structure = imap_fetchstructure(
             $this->stream,

--- a/src/Server.php
+++ b/src/Server.php
@@ -74,11 +74,13 @@ class Server
     public function authenticate($username, $password)
     {
         // Wrap imap_open, which gives notices instead of exceptions
-        set_error_handler(
-            function ($nr, $message) use ($username) {
-                throw new AuthenticationFailedException($username, $message);
-            }
-        );
+        set_error_handler(function ($nr, $message) use ($username) {
+            throw new AuthenticationFailedException(sprintf(
+                'Authentication failed for user "%s": %s',
+                $username,
+                $message
+            ), $nr);
+        });
 
         $resource = imap_open(
             $this->getServerString(),
@@ -89,11 +91,11 @@ class Server
             $this->parameters
         );
 
+        restore_error_handler();
+
         if (false === $resource) {
             throw new AuthenticationFailedException($username);
         }
-
-        restore_error_handler();
 
         $check = imap_check($resource);
         $mailbox = $check->Mailbox;

--- a/tests/MailboxTest.php
+++ b/tests/MailboxTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ddeboer\Imap\Tests;
 
+use Ddeboer\Imap\Exception;
 use Ddeboer\Imap\Mailbox;
 use Ddeboer\Imap\Search\Email\To;
 use Ddeboer\Imap\Search\Text\Body;
@@ -40,13 +41,12 @@ class MailboxTest extends AbstractTest
         $this->assertEquals(3, $i);
     }
 
-    /**
-     * @expectedException \Ddeboer\Imap\Exception\MessageDoesNotExistException
-     * @expectedExceptionMessageRegExp /Message 666 does not exist.*Bad message number/
-     */
     public function testGetMessageThrowsException()
     {
-        $this->mailbox->getMessage(666);
+        $this->expectException(Exception\MessageDoesNotExistException::class);
+        $this->expectExceptionMessageRegExp('/E_WARNING.+Message 999 does not exist.+Bad message number/s');
+
+        $this->mailbox->getMessage(999);
     }
 
     public function testCount()

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -11,7 +11,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
 {
     public function testFailedAuthenticate()
     {
-        $server = new Server(\getenv('IMAP_SERVER_NAME'), \getenv('IMAP_SERVER_PORT'));
+        $server = new Server(\getenv('IMAP_SERVER_NAME'), \getenv('IMAP_SERVER_PORT'), '/imap/ssl/novalidate-cert');
 
         $this->expectException(Exception\AuthenticationFailedException::class);
         $this->expectExceptionMessageRegExp('/E_WARNING.+AUTHENTICATIONFAILED/s');

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -4,16 +4,18 @@ declare(strict_types=1);
 
 namespace Ddeboer\Imap\Tests;
 
+use Ddeboer\Imap\Exception;
 use Ddeboer\Imap\Server;
 
 class ServerTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @expectedException \Ddeboer\Imap\Exception\AuthenticationFailedException
-     */
     public function testFailedAuthenticate()
     {
-        $server = new Server('imap.gmail.com');
-        $server->authenticate('fake_username', 'fake_password');
+        $server = new Server(\getenv('IMAP_SERVER_NAME'), \getenv('IMAP_SERVER_PORT'));
+
+        $this->expectException(Exception\AuthenticationFailedException::class);
+        $this->expectExceptionMessageRegExp('/E_WARNING.+AUTHENTICATIONFAILED/s');
+
+        $server->authenticate(uniqid('fake_username_'), uniqid('fake_password_'));
     }
 }


### PR DESCRIPTION
Call [imap_alerts()](https://secure.php.net/manual/en/function.imap-alerts.php) and [imap_errors()](https://secure.php.net/manual/en/function.imap-errors.php) while building Exception message to increase verbosity and raise awareness of what happened.

Before:
```
Authentication failed for user "fake_username_59c9f91cc66e6": imap_open():
Couldn't open stream {my.server.com:60993/imap/ssl/validate-cert}
```
After:
```
[E_WARNING] Authentication failed for user "fake_username_59c9f91cc66e6": imap_open():
Couldn't open stream {my.server.com:60993/imap/ssl/validate-cert}
imap_alerts (0):
imap_errors (1):
- Can not authenticate to IMAP server: [AUTHENTICATIONFAILED] Authentication failed.
```