### PR TITLE
Retain `imap_getmailboxes` results

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -27,12 +27,11 @@ class Connection implements \Countable
      */
     public function __construct($resource, string $server)
     {
-        if (false === is_resource($resource)) {
-            throw new \InvalidArgumentException('$resource must be a resource');
-        }
-
         $this->resource = $resource;
         $this->server = $server;
+
+        // Performs resource check
+        $this->getResource();
     }
 
     /**
@@ -42,6 +41,10 @@ class Connection implements \Countable
      */
     public function getResource()
     {
+        if (false === is_resource($this->resource) || 'imap' !== get_resource_type($this->resource)) {
+            throw new Exception('Supplied resource is not a valid imap resource');
+        }
+
         return $this->resource;
     }
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -10,7 +10,7 @@ use Ddeboer\Imap\Exception\MailboxDoesNotExistException;
 /**
  * A connection to an IMAP server that is authenticated for a user
  */
-class Connection
+class Connection implements \Countable
 {
     private $server;
     private $resource;
@@ -27,12 +27,44 @@ class Connection
      */
     public function __construct($resource, string $server)
     {
-        if (!is_resource($resource)) {
+        if (false === is_resource($resource)) {
             throw new \InvalidArgumentException('$resource must be a resource');
         }
 
         $this->resource = $resource;
         $this->server = $server;
+    }
+
+    /**
+     * Get IMAP resource
+     *
+     * @return resource
+     */
+    public function getResource()
+    {
+        return $this->resource;
+    }
+
+    /**
+     * Delete all messages marked for deletion
+     *
+     * @return Mailbox
+     */
+    public function expunge()
+    {
+        imap_expunge($this->getResource());
+    }
+
+    /**
+     * Close connection
+     *
+     * @param int $flag
+     *
+     * @return bool
+     */
+    public function close(int $flag = 0): bool
+    {
+        return imap_close($this->getResource(), $flag);
     }
 
     /**
@@ -42,10 +74,12 @@ class Connection
      */
     public function getMailboxes(): array
     {
+        $this->initMailboxNames();
+
         if (null === $this->mailboxes) {
             $this->mailboxes = [];
-            foreach ($this->getMailboxNames() as $mailboxName) {
-                $this->mailboxes[] = $this->getMailbox($mailboxName);
+            foreach ($this->mailboxNames as $mailboxName => $mailboxInfo) {
+                $this->mailboxes[$mailboxName] = $this->getMailbox($mailboxName);
             }
         }
 
@@ -61,7 +95,9 @@ class Connection
      */
     public function hasMailbox(string $name): bool
     {
-        return in_array($name, $this->getMailboxNames());
+        $this->initMailboxNames();
+
+        return isset($this->mailboxNames[$name]);
     }
 
     /**
@@ -75,14 +111,14 @@ class Connection
      */
     public function getMailbox(string $name): Mailbox
     {
-        if (!$this->hasMailbox($name)) {
+        if (false === $this->hasMailbox($name)) {
             throw new MailboxDoesNotExistException(sprintf(
-                'Mailbox "%s" does not exist',
+                'Mailbox name "%s" does not exist',
                 $name
             ));
         }
 
-        return new Mailbox($this->server . imap_utf7_encode($name), $this);
+        return new Mailbox($this, $name, $this->mailboxNames[$name]);
     }
 
     /**
@@ -92,7 +128,7 @@ class Connection
      */
     public function count()
     {
-        return imap_num_msg($this->resource);
+        return imap_num_msg($this->getResource());
     }
 
     /**
@@ -106,8 +142,12 @@ class Connection
      */
     public function createMailbox(string $name): Mailbox
     {
-        if (false === imap_createmailbox($this->resource, $this->server . $name)) {
-            throw new Exception("Can not create '{$name}' mailbox at '{$this->server}'");
+        if (false === imap_createmailbox($this->getResource(), $this->server . imap_utf7_encode($name))) {
+            throw new Exception(sprintf(
+                'Can not create "%s" mailbox at "%s"',
+                $name,
+                $this->server
+            ));
         }
 
         $this->mailboxNames = $this->mailboxes = null;
@@ -115,35 +155,16 @@ class Connection
         return $this->getMailbox($name);
     }
 
-    /**
-     * Close connection
-     *
-     * @param int $flag
-     *
-     * @return bool
-     */
-    public function close(int $flag = 0): bool
-    {
-        return imap_close($this->resource, $flag);
-    }
-
     public function deleteMailbox(Mailbox $mailbox)
     {
-        if (false === imap_deletemailbox($this->resource, $this->server . $mailbox->getName())) {
-            throw new Exception('Mailbox ' . $mailbox->getName() . ' could not be deleted');
+        if (false === imap_deletemailbox($this->getResource(), $mailbox->getFullEncodedName())) {
+            throw new Exception(sprintf(
+                'Mailbox "%s" could not be deleted',
+                $mailbox->getName()
+            ));
         }
 
         $this->mailboxes = $this->mailboxNames = null;
-    }
-
-    /**
-     * Get IMAP resource
-     *
-     * @return resource
-     */
-    public function getResource()
-    {
-        return $this->resource;
     }
 
     /**
@@ -151,16 +172,17 @@ class Connection
      *
      * @return array
      */
-    private function getMailboxNames(): array
+    private function initMailboxNames()
     {
-        if (null === $this->mailboxNames) {
-            $this->mailboxNames = [];
-            $mailboxes = imap_getmailboxes($this->resource, $this->server, '*');
-            foreach ($mailboxes as $mailbox) {
-                $this->mailboxNames[] = imap_utf7_decode(str_replace($this->server, '', $mailbox->name));
-            }
+        if (null !== $this->mailboxNames) {
+            return;
         }
 
-        return $this->mailboxNames;
+        $this->mailboxNames = [];
+        $mailboxesInfo = imap_getmailboxes($this->getResource(), $this->server, '*');
+        foreach ($mailboxesInfo as $mailboxInfo) {
+            $name = imap_utf7_decode(str_replace($this->server, '', $mailboxInfo->name));
+            $this->mailboxNames[$name] = $mailboxInfo;
+        }
     }
 }

--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Ddeboer\Imap;
 
+use Ddeboer\Imap\Exception\Exception;
+
 /**
  * An IMAP mailbox (commonly referred to as a 'folder')
  */
@@ -160,9 +162,23 @@ class Mailbox implements \Countable, \IteratorAggregate
      */
     private function init()
     {
-        $check = imap_check($this->connection->getResource());
-        if ($check === false || $check->Mailbox != $this->getFullEncodedName()) {
-            imap_reopen($this->connection->getResource(), $this->getFullEncodedName());
+        if ($this->isMailboxOpen()) {
+            return;
         }
+
+        imap_reopen($this->connection->getResource(), $this->getFullEncodedName());
+
+        if ($this->isMailboxOpen()) {
+            return;
+        }
+
+        throw new Exception(sprintf('Cannot reopen mailbox "%s"', $this->getName()));
+    }
+
+    private function isMailboxOpen(): bool
+    {
+        $check = imap_check($this->connection->getResource());
+
+        return false !== $check && $check->Mailbox === $this->getFullEncodedName();
     }
 }

--- a/src/Server.php
+++ b/src/Server.php
@@ -27,11 +27,6 @@ class Server
     private $flags;
 
     /**
-     * @var string
-     */
-    private $connection;
-
-    /**
      * @var array
      */
     private $parameters;
@@ -99,13 +94,13 @@ class Server
 
         $check = imap_check($resource);
         $mailbox = $check->Mailbox;
-        $this->connection = substr($mailbox, 0, strpos($mailbox, '}') + 1);
+        $connection = substr($mailbox, 0, strpos($mailbox, '}') + 1);
 
         // These are necessary to get rid of PHP throwing IMAP errors
         imap_errors();
         imap_alerts();
 
-        return new Connection($resource, $this->connection);
+        return new Connection($resource, $connection);
     }
 
     /**

--- a/tests/AbstractTest.php
+++ b/tests/AbstractTest.php
@@ -18,11 +18,17 @@ abstract class AbstractTest extends PHPUnit_Framework_TestCase
     {
         static $connection;
         if (null === $connection) {
-            $server = new Server(\getenv('IMAP_SERVER_NAME'), \getenv('IMAP_SERVER_PORT'), self::IMAP_FLAGS);
-            $connection = $server->authenticate(\getenv('IMAP_USERNAME'), \getenv('IMAP_PASSWORD'));
+            $connection = $this->createConnection();
         }
 
         return $connection;
+    }
+
+    final protected function createConnection()
+    {
+        $server = new Server(\getenv('IMAP_SERVER_NAME'), \getenv('IMAP_SERVER_PORT'), self::IMAP_FLAGS);
+
+        return $server->authenticate(\getenv('IMAP_USERNAME'), \getenv('IMAP_PASSWORD'));
     }
 
     final protected function createMailbox()

--- a/tests/AbstractTest.php
+++ b/tests/AbstractTest.php
@@ -10,11 +10,15 @@ use PHPUnit_Framework_TestCase;
 
 abstract class AbstractTest extends PHPUnit_Framework_TestCase
 {
+    const IMAP_FLAGS = '/imap/ssl/novalidate-cert';
+
+    const NON_PRINTABLE_ASCII = 'A_è_π_Z_';
+
     final protected function getConnection()
     {
         static $connection;
         if (null === $connection) {
-            $server = new Server(\getenv('IMAP_SERVER_NAME'), \getenv('IMAP_SERVER_PORT'), '/imap/ssl/novalidate-cert');
+            $server = new Server(\getenv('IMAP_SERVER_NAME'), \getenv('IMAP_SERVER_PORT'), self::IMAP_FLAGS);
             $connection = $server->authenticate(\getenv('IMAP_USERNAME'), \getenv('IMAP_PASSWORD'));
         }
 
@@ -23,7 +27,7 @@ abstract class AbstractTest extends PHPUnit_Framework_TestCase
 
     final protected function createMailbox()
     {
-        $this->mailboxName = uniqid('mailbox_');
+        $this->mailboxName = uniqid('mailbox_' . self::NON_PRINTABLE_ASCII);
 
         return $this->getConnection()->createMailbox($this->mailboxName);
     }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -4,47 +4,52 @@ declare(strict_types=1);
 
 namespace Ddeboer\Imap\Tests;
 
+use Ddeboer\Imap\Connection;
+use Ddeboer\Imap\Exception\Exception;
 use Ddeboer\Imap\Exception\MailboxDoesNotExistException;
+use Ddeboer\Imap\Mailbox;
 
+/**
+ * @covers \Ddeboer\Imap\Connection
+ */
 class ConnectionTest extends AbstractTest
 {
+    public function testCannotInstantiateArbitraryConnections()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new Connection(uniqid(), uniqid());
+    }
+
     public function testCount()
     {
-        $this->assertInternalType('int', self::getConnection()->count());
+        $this->assertInternalType('int', $this->getConnection()->count());
     }
 
     public function testGetMailboxes()
     {
-        $mailboxes = self::getConnection()->getMailboxes();
+        $mailboxes = $this->getConnection()->getMailboxes();
         $this->assertInternalType('array', $mailboxes);
 
         foreach ($mailboxes as $mailbox) {
-            $this->assertInstanceOf('\Ddeboer\Imap\Mailbox', $mailbox);
+            $this->assertInstanceOf(Mailbox::class, $mailbox);
         }
     }
 
     public function testGetMailbox()
     {
-        $mailbox = static::getConnection()->getMailbox('INBOX');
-        $this->assertInstanceOf('\Ddeboer\Imap\Mailbox', $mailbox);
+        $mailbox = $this->getConnection()->getMailbox('INBOX');
+        $this->assertInstanceOf(Mailbox::class, $mailbox);
     }
 
     public function testCreateMailbox()
     {
-        $connection = static::getConnection();
+        $connection = $this->getConnection();
 
-        $name = 'test' . uniqid();
+        $name = uniqid('test_');
         $mailbox = $connection->createMailbox($name);
-        $this->assertEquals(
-            $name,
-            $mailbox->getName(),
-            'Correct mailbox must be returned from create'
-        );
-        $this->assertEquals(
-            $name,
-            $connection->getMailbox($name)->getName(),
-            'Correct mailbox must be returned from connection'
-        );
+        $this->assertSame($name, $mailbox->getName());
+        $this->assertSame($name, $connection->getMailbox($name)->getName());
 
         $mailbox->delete();
 
@@ -53,9 +58,30 @@ class ConnectionTest extends AbstractTest
         $connection->getMailbox($name);
     }
 
+    public function testCannotCreateMailboxesOnReadonly()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageRegExp('/ALREADYEXISTS/');
+
+        $this->getConnection()->createMailbox('INBOX');
+    }
+
+    public function testEscapesMailboxNames()
+    {
+        $this->assertInstanceOf(Mailbox::class, $this->getConnection()->createMailbox(uniqid(self::NON_PRINTABLE_ASCII)));
+    }
+
+    public function testCustomExceptionOnInvalidMailboxName()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageRegExp('/Mailbox name is not valid mUTF-7/');
+
+        $this->assertInstanceOf(Mailbox::class, $this->getConnection()->createMailbox(uniqid('A_€_')));
+    }
+
     public function testGetInvalidMailbox()
     {
         $this->expectException(MailboxDoesNotExistException::class);
-        static::getConnection()->getMailbox('does-not-exist');
+        $this->getConnection()->getMailbox('does-not-exist');
     }
 }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -16,9 +16,19 @@ class ConnectionTest extends AbstractTest
 {
     public function testCannotInstantiateArbitraryConnections()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(Exception::class);
 
         new Connection(uniqid(), uniqid());
+    }
+
+    public function testCloseConnection()
+    {
+        $connection = $this->createConnection();
+        $connection->close();
+
+        $this->expectException(Exception::class);
+
+        $connection->close();
     }
 
     public function testCount()
@@ -58,10 +68,22 @@ class ConnectionTest extends AbstractTest
         $connection->getMailbox($name);
     }
 
+    public function testCannotDeleteInvalidMailbox()
+    {
+        $mailbox = $this->createMailbox();
+
+        $mailbox->delete();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageRegExp('/NONEXISTENT/');
+
+        $mailbox->delete();
+    }
+
     public function testCannotCreateMailboxesOnReadonly()
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessageRegExp('/ALREADYEXISTS/');
+        $this->expectExceptionMessageRegExp('/(SERVERBUG|ALREADYEXISTS)/');
 
         $this->getConnection()->createMailbox('INBOX');
     }

--- a/tests/MailboxTest.php
+++ b/tests/MailboxTest.php
@@ -10,6 +10,9 @@ use Ddeboer\Imap\Search\Email\To;
 use Ddeboer\Imap\Search\Text\Body;
 use Ddeboer\Imap\SearchExpression;
 
+/**
+ * @covers \Ddeboer\Imap\Mailbox
+ */
 class MailboxTest extends AbstractTest
 {
     /**
@@ -29,6 +32,13 @@ class MailboxTest extends AbstractTest
     public function testGetName()
     {
         $this->assertSame($this->mailboxName, $this->mailbox->getName());
+    }
+
+    public function testGet()
+    {
+        $this->assertContains(\getenv('IMAP_SERVER_NAME'), $this->mailbox->getFullEncodedName());
+        $this->assertNotContains($this->mailboxName, $this->mailbox->getFullEncodedName());
+        $this->assertContains(imap_utf7_encode($this->mailboxName), $this->mailbox->getFullEncodedName());
     }
 
     public function testGetMessages()

--- a/tests/MailboxTest.php
+++ b/tests/MailboxTest.php
@@ -34,21 +34,38 @@ class MailboxTest extends AbstractTest
         $this->assertSame($this->mailboxName, $this->mailbox->getName());
     }
 
-    public function testGet()
+    public function testGetFullEncodedName()
     {
-        $this->assertContains(\getenv('IMAP_SERVER_NAME'), $this->mailbox->getFullEncodedName());
+        $this->assertContains(\getenv('IMAP_SERVER_PORT'), $this->mailbox->getFullEncodedName());
         $this->assertNotContains($this->mailboxName, $this->mailbox->getFullEncodedName());
         $this->assertContains(imap_utf7_encode($this->mailboxName), $this->mailbox->getFullEncodedName());
     }
 
+    public function testGetAttributes()
+    {
+        $this->assertGreaterThan(0, $this->mailbox->getAttributes() & LATT_HASNOCHILDREN);
+    }
+
+    public function testGetDelimiter()
+    {
+        $this->assertSame('.', $this->mailbox->getDelimiter());
+    }
+
     public function testGetMessages()
     {
-        $i = 0;
+        $directMethodInc = 0;
         foreach ($this->mailbox->getMessages() as $message) {
-            ++$i;
+            ++$directMethodInc;
         }
 
-        $this->assertEquals(3, $i);
+        $this->assertSame(3, $directMethodInc);
+
+        $aggregateIteratorMethodInc = 0;
+        foreach ($this->mailbox as $message) {
+            ++$aggregateIteratorMethodInc;
+        }
+
+        $this->assertSame(3, $aggregateIteratorMethodInc);
     }
 
     public function testGetMessageThrowsException()
@@ -83,5 +100,14 @@ class MailboxTest extends AbstractTest
         $search = new SearchExpression();
         $search->addCondition(new To('nope@nope.com'));
         $this->assertCount(0, $this->mailbox->getMessages($search));
+    }
+
+    public function testDelete()
+    {
+        $this->mailbox->delete();
+
+        $this->expectException(Exception\Exception::class);
+
+        $this->mailbox->count();
     }
 }

--- a/tests/MailboxTest.php
+++ b/tests/MailboxTest.php
@@ -43,12 +43,12 @@ class MailboxTest extends AbstractTest
 
     public function testGetAttributes()
     {
-        $this->assertGreaterThan(0, $this->mailbox->getAttributes() & LATT_HASNOCHILDREN);
+        $this->assertInternalType('integer', $this->mailbox->getAttributes());
     }
 
     public function testGetDelimiter()
     {
-        $this->assertSame('.', $this->mailbox->getDelimiter());
+        $this->assertInternalType('string', $this->mailbox->getDelimiter());
     }
 
     public function testGetMessages()

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Ddeboer\Imap\Tests;
 
+/**
+ * @covers \Ddeboer\Imap\Message
+ * @covers \Ddeboer\Imap\Mailbox::expunge
+ * @covers \Ddeboer\Imap\Connection::expunge
+ */
 class MessageTest extends AbstractTest
 {
     /**

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -7,11 +7,23 @@ namespace Ddeboer\Imap\Tests;
 use Ddeboer\Imap\Exception;
 use Ddeboer\Imap\Server;
 
-class ServerTest extends \PHPUnit_Framework_TestCase
+/**
+ * @covers \Ddeboer\Imap\Server
+ */
+class ServerTest extends AbstractTest
 {
+    public function testValidConnection()
+    {
+        $connection = $this->getConnection();
+
+        $check = imap_check($connection->getResource());
+
+        $this->assertInstanceOf(\stdClass::class, $check);
+    }
+
     public function testFailedAuthenticate()
     {
-        $server = new Server(\getenv('IMAP_SERVER_NAME'), \getenv('IMAP_SERVER_PORT'), '/imap/ssl/novalidate-cert');
+        $server = new Server(\getenv('IMAP_SERVER_NAME'), \getenv('IMAP_SERVER_PORT'), self::IMAP_FLAGS);
 
         $this->expectException(Exception\AuthenticationFailedException::class);
         $this->expectExceptionMessageRegExp('/E_WARNING.+AUTHENTICATIONFAILED/s');


### PR DESCRIPTION
- [x] Keep both mailbox server encoded name and decoded path resulted by `imap_getmailboxes`
- [x] Keep `imap_getmailboxes` infos both in Connection and in Mailbox (closes https://github.com/ddeboer/imap/issues/167)
- [x] Encode mailbox name only where it's needed: during mailbox creation
- [x] Decode mailbox name only where it's needed: during `imap_getmailboxes`
- [x] Restrict code-coverage with [@covers](https://phpunit.de/manual/current/en/appendixes.annotations.html#appendixes.annotations.covers) annotation
- [x] Get 100% code-coverage on `Connection` and `Mailbox`

#### BC Breaks

Signature of `Ddeboer\Imap\Mailbox` changed.