### PR TITLE
SearchCondition: __toString() -> toString()

### DIFF
--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -92,7 +92,7 @@ class Mailbox implements \Countable, \IteratorAggregate
     {
         $this->init();
 
-        $query = ($search ? (string) $search : 'ALL');
+        $query = ($search ? $search->toString() : 'ALL');
 
         $messageNumbers = imap_search($this->connection->getResource(), $query, \SE_UID);
         if (false == $messageNumbers) {

--- a/src/Search/AbstractCondition.php
+++ b/src/Search/AbstractCondition.php
@@ -7,14 +7,14 @@ namespace Ddeboer\Imap\Search;
 /**
  * Represents a condition that can be used in a search expression.
  */
-abstract class AbstractCondition
+abstract class AbstractCondition implements ConditionInterface
 {
     /**
      * Converts the condition to a string that can be sent to the IMAP server.
      *
      * @return string
      */
-    public function __toString()
+    public function toString(): string
     {
         return $this->getKeyword();
     }

--- a/src/Search/ConditionInterface.php
+++ b/src/Search/ConditionInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ddeboer\Imap\Search;
+
+/**
+ * Represents a condition that can be used in a search expression.
+ */
+interface ConditionInterface
+{
+    /**
+     * Converts the condition to a string that can be sent to the IMAP server.
+     *
+     * @return string
+     */
+    public function toString(): string;
+}

--- a/src/Search/Date/AbstractDate.php
+++ b/src/Search/Date/AbstractDate.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Ddeboer\Imap\Search\Date;
 
-use DateTime;
+use DateTimeInterface;
 use Ddeboer\Imap\Search\AbstractCondition;
 
 /**
@@ -22,28 +22,16 @@ abstract class AbstractDate extends AbstractCondition
     /**
      * The date to be used for the condition.
      *
-     * @var DateTime
+     * @var DateTimeInterface
      */
-    protected $date;
+    private $date;
 
     /**
      * Constructor.
      *
-     * @param DateTime $date optional date for the condition
+     * @param DateTimeInterface $date optional date for the condition
      */
-    public function __construct(DateTime $date = null)
-    {
-        if ($date) {
-            $this->setDate($date);
-        }
-    }
-
-    /**
-     * Sets the date for the condition.
-     *
-     * @param DateTime $date
-     */
-    public function setDate(DateTime $date)
+    public function __construct(DateTimeInterface $date)
     {
         $this->date = $date;
     }
@@ -53,8 +41,8 @@ abstract class AbstractDate extends AbstractCondition
      *
      * @return string
      */
-    public function __toString()
+    final public function toString(): string
     {
-        return $this->getKeyword() . ' "' . $this->date->format(self::DATE_FORMAT) . '"';
+        return sprintf('%s "%s"', $this->getKeyword(), $this->date->format(self::DATE_FORMAT));
     }
 }

--- a/src/Search/Date/After.php
+++ b/src/Search/Date/After.php
@@ -8,14 +8,14 @@ namespace Ddeboer\Imap\Search\Date;
  * Represents a date after condition. Messages must have a date after the
  * specified date in order to match the condition.
  */
-class After extends AbstractDate
+final class After extends AbstractDate
 {
     /**
      * Returns the keyword that the condition represents.
      *
      * @return string
      */
-    public function getKeyword(): string
+    protected function getKeyword(): string
     {
         return 'SINCE';
     }

--- a/src/Search/Date/Before.php
+++ b/src/Search/Date/Before.php
@@ -8,14 +8,14 @@ namespace Ddeboer\Imap\Search\Date;
  * Represents a date before condition. Messages must have a date before the
  * specified date in order to match the condition.
  */
-class Before extends AbstractDate
+final class Before extends AbstractDate
 {
     /**
      * Returns the keyword that the condition represents.
      *
      * @return string
      */
-    public function getKeyword(): string
+    protected function getKeyword(): string
     {
         return 'BEFORE';
     }

--- a/src/Search/Date/On.php
+++ b/src/Search/Date/On.php
@@ -8,14 +8,14 @@ namespace Ddeboer\Imap\Search\Date;
  * Represents a date on condition. Messages must have a date matching the
  * specified date in order to match the condition.
  */
-class On extends AbstractDate
+final class On extends AbstractDate
 {
     /**
      * Returns the keyword that the condition represents.
      *
      * @return string
      */
-    public function getKeyword(): string
+    protected function getKeyword(): string
     {
         return 'ON';
     }

--- a/src/Search/Email/AbstractEmail.php
+++ b/src/Search/Email/AbstractEmail.php
@@ -16,26 +16,14 @@ abstract class AbstractEmail extends AbstractCondition
      *
      * @var string
      */
-    protected $email;
+    private $email;
 
     /**
      * Constructor
      *
      * @param string $email optional email address for the condition
      */
-    public function __construct(string $email = null)
-    {
-        if ($email) {
-            $this->setEmail($email);
-        }
-    }
-
-    /**
-     * Sets the email address for the condition.
-     *
-     * @param string $email
-     */
-    public function setEmail(string $email)
+    public function __construct(string $email)
     {
         $this->email = $email;
     }
@@ -45,8 +33,8 @@ abstract class AbstractEmail extends AbstractCondition
      *
      * @return string
      */
-    public function __toString()
+    final public function toString(): string
     {
-        return $this->getKeyword() . ' "' . $this->email . '"';
+        return sprintf('%s "%s"', $this->getKeyword(), $this->email);
     }
 }

--- a/src/Search/Email/FromAddress.php
+++ b/src/Search/Email/FromAddress.php
@@ -8,14 +8,14 @@ namespace Ddeboer\Imap\Search\Email;
  * Represents a "From" email address condition. Messages must have been sent
  * from the specified email address in order to match the condition.
  */
-class FromAddress extends AbstractEmail
+final class FromAddress extends AbstractEmail
 {
     /**
      * Returns the keyword that the condition represents.
      *
      * @return string
      */
-    public function getKeyword(): string
+    protected function getKeyword(): string
     {
         return 'FROM';
     }

--- a/src/Search/Email/To.php
+++ b/src/Search/Email/To.php
@@ -9,14 +9,14 @@ namespace Ddeboer\Imap\Search\Email;
  * to the specified recipient (along with any others) in order to match the
  * condition.
  */
-class To extends AbstractEmail
+final class To extends AbstractEmail
 {
     /**
      * Returns the keyword that the condition represents.
      *
      * @return string
      */
-    public function getKeyword(): string
+    protected function getKeyword(): string
     {
         return 'TO';
     }

--- a/src/Search/Flag/Answered.php
+++ b/src/Search/Flag/Answered.php
@@ -10,14 +10,14 @@ use Ddeboer\Imap\Search\AbstractCondition;
  * Represents an ANSWERED flag condition. Messages must have the \\ANSWERED flag
  * set in order to match the condition.
  */
-class Answered extends AbstractCondition
+final class Answered extends AbstractCondition
 {
     /**
      * Returns the keyword that the condition represents.
      *
      * @return string
      */
-    public function getKeyword(): string
+    protected function getKeyword(): string
     {
         return 'ANSWERED';
     }

--- a/src/Search/Flag/Flagged.php
+++ b/src/Search/Flag/Flagged.php
@@ -10,14 +10,14 @@ use Ddeboer\Imap\Search\AbstractCondition;
  * Represents a FLAGGED flag condition. Messages must have the \\FLAGGED flag
  * (i.e. urgent or important) set in order to match the condition.
  */
-class Flagged extends AbstractCondition
+final class Flagged extends AbstractCondition
 {
     /**
      * Returns the keyword that the condition represents.
      *
      * @return string
      */
-    public function getKeyword(): string
+    protected function getKeyword(): string
     {
         return 'FLAGGED';
     }

--- a/src/Search/Flag/Recent.php
+++ b/src/Search/Flag/Recent.php
@@ -10,14 +10,14 @@ use Ddeboer\Imap\Search\AbstractCondition;
  * Represents an RECENT flag condition. Messages must have the \\RECENT flag
  * set in order to match the condition.
  */
-class Recent extends AbstractCondition
+final class Recent extends AbstractCondition
 {
     /**
      * Returns the keyword that the condition represents.
      *
      * @return string
      */
-    public function getKeyword(): string
+    protected function getKeyword(): string
     {
         return 'RECENT';
     }

--- a/src/Search/Flag/Seen.php
+++ b/src/Search/Flag/Seen.php
@@ -10,14 +10,14 @@ use Ddeboer\Imap\Search\AbstractCondition;
  * Represents an SEEN flag condition. Messages must have the \\SEEN flag
  * set in order to match the condition.
  */
-class Seen extends AbstractCondition
+final class Seen extends AbstractCondition
 {
     /**
      * Returns the keyword that the condition represents.
      *
      * @return string
      */
-    public function getKeyword(): string
+    protected function getKeyword(): string
     {
         return 'SEEN';
     }

--- a/src/Search/Flag/Unanswered.php
+++ b/src/Search/Flag/Unanswered.php
@@ -10,14 +10,14 @@ use Ddeboer\Imap\Search\AbstractCondition;
  * Represents an UNANSWERED flag condition. Messages must not have the
  * \\ANSWERED flag set in order to match the condition.
  */
-class Unanswered extends AbstractCondition
+final class Unanswered extends AbstractCondition
 {
     /**
      * Returns the keyword that the condition represents.
      *
      * @return string
      */
-    public function getKeyword(): string
+    protected function getKeyword(): string
     {
         return 'UNANSWERED';
     }

--- a/src/Search/Flag/Unflagged.php
+++ b/src/Search/Flag/Unflagged.php
@@ -10,14 +10,14 @@ use Ddeboer\Imap\Search\AbstractCondition;
  * Represents a UNFLAGGED flag condition. Messages must no have the \\FLAGGED
  * flag (i.e. urgent or important) set in order to match the condition.
  */
-class Unflagged extends AbstractCondition
+final class Unflagged extends AbstractCondition
 {
     /**
      * Returns the keyword that the condition represents.
      *
      * @return string
      */
-    public function getKeyword(): string
+    protected function getKeyword(): string
     {
         return 'UNFLAGGED';
     }

--- a/src/Search/Flag/Unseen.php
+++ b/src/Search/Flag/Unseen.php
@@ -10,14 +10,14 @@ use Ddeboer\Imap\Search\AbstractCondition;
  * Represents an UNSEEN flag condition. Messages must not have the \\SEEN flag
  * set in order to match the condition.
  */
-class Unseen extends AbstractCondition
+final class Unseen extends AbstractCondition
 {
     /**
      * Returns the keyword that the condition represents.
      *
      * @return string
      */
-    public function getKeyword(): string
+    protected function getKeyword(): string
     {
         return 'UNSEEN';
     }

--- a/src/Search/LogicalOperator/All.php
+++ b/src/Search/LogicalOperator/All.php
@@ -10,14 +10,14 @@ use Ddeboer\Imap\Search\AbstractCondition;
  * Represents an ALL operator. Messages must match all conditions following this
  * operator in order to match the expression.
  */
-class All extends AbstractCondition
+final class All extends AbstractCondition
 {
     /**
      * Returns the keyword that the condition represents.
      *
      * @return string
      */
-    public function getKeyword(): string
+    protected function getKeyword(): string
     {
         return 'ALL';
     }

--- a/src/Search/LogicalOperator/OrConditions.php
+++ b/src/Search/LogicalOperator/OrConditions.php
@@ -10,14 +10,14 @@ use Ddeboer\Imap\Search\AbstractCondition;
  * Represents an OR operator. Messages only need to match one of the conditions
  * after this operator to match the expression.
  */
-class OrConditions extends AbstractCondition
+final class OrConditions extends AbstractCondition
 {
     /**
      * Returns the keyword that the condition represents.
      *
      * @return string
      */
-    public function getKeyword(): string
+    protected function getKeyword(): string
     {
         return 'OR';
     }

--- a/src/Search/State/Deleted.php
+++ b/src/Search/State/Deleted.php
@@ -10,14 +10,14 @@ use Ddeboer\Imap\Search\AbstractCondition;
  * Represents a DELETED condition. Messages must have been marked for deletion
  * but not yet expunged in order to match the condition.
  */
-class Deleted extends AbstractCondition
+final class Deleted extends AbstractCondition
 {
     /**
      * Returns the keyword that the condition represents.
      *
      * @return string
      */
-    public function getKeyword(): string
+    protected function getKeyword(): string
     {
         return 'DELETED';
     }

--- a/src/Search/State/NewMessage.php
+++ b/src/Search/State/NewMessage.php
@@ -9,14 +9,14 @@ use Ddeboer\Imap\Search\AbstractCondition;
 /**
  * Represents a NEW condition. Only new messages will match this condition.
  */
-class NewMessage extends AbstractCondition
+final class NewMessage extends AbstractCondition
 {
     /**
      * Returns the keyword that the condition represents.
      *
      * @return string
      */
-    public function getKeyword(): string
+    protected function getKeyword(): string
     {
         return 'NEW';
     }

--- a/src/Search/State/Old.php
+++ b/src/Search/State/Old.php
@@ -9,14 +9,14 @@ use Ddeboer\Imap\Search\AbstractCondition;
 /**
  * Represents an OLD condition. Only old messages will match this condition.
  */
-class Old extends AbstractCondition
+final class Old extends AbstractCondition
 {
     /**
      * Returns the keyword that the condition represents.
      *
      * @return string
      */
-    public function getKeyword(): string
+    protected function getKeyword(): string
     {
         return 'OLD';
     }

--- a/src/Search/State/Undeleted.php
+++ b/src/Search/State/Undeleted.php
@@ -10,14 +10,14 @@ use Ddeboer\Imap\Search\AbstractCondition;
  * Represents a UNDELETED condition. Messages must not have been marked for
  * deletion in order to match the condition.
  */
-class Undeleted extends AbstractCondition
+final class Undeleted extends AbstractCondition
 {
     /**
      * Returns the keyword that the condition represents.
      *
      * @return string
      */
-    public function getKeyword(): string
+    protected function getKeyword(): string
     {
         return 'UNDELETED';
     }

--- a/src/Search/Text/AbstractText.php
+++ b/src/Search/Text/AbstractText.php
@@ -17,26 +17,14 @@ abstract class AbstractText extends AbstractCondition
      *
      * @var string
      */
-    protected $text;
+    private $text;
 
     /**
      * Constructor.
      *
      * @param string $text optional text for the condition
      */
-    public function __construct(string $text = null)
-    {
-        if (null !== $text && strlen($text) > 0) {
-            $this->setText($text);
-        }
-    }
-
-    /**
-     * Sets the text for the condition.
-     *
-     * @param string $text
-     */
-    public function setText(string $text)
+    public function __construct(string $text)
     {
         $this->text = $text;
     }
@@ -46,8 +34,8 @@ abstract class AbstractText extends AbstractCondition
      *
      * @return string
      */
-    public function __toString()
+    final public function toString(): string
     {
-        return $this->getKeyword() . ' "' . str_replace('"', '\\"', $this->text) . '"';
+        return sprintf('%s "%s"', $this->getKeyword(), str_replace('"', '\\"', $this->text));
     }
 }

--- a/src/Search/Text/Body.php
+++ b/src/Search/Text/Body.php
@@ -8,14 +8,14 @@ namespace Ddeboer\Imap\Search\Text;
  * Represents a body text contains condition. Messages must have a body
  * containing the specified text in order to match the condition.
  */
-class Body extends Text
+final class Body extends AbstractText
 {
     /**
      * Returns the keyword that the condition represents.
      *
      * @return string
      */
-    public function getKeyword(): string
+    protected function getKeyword(): string
     {
         return 'BODY';
     }

--- a/src/Search/Text/Keyword.php
+++ b/src/Search/Text/Keyword.php
@@ -8,14 +8,14 @@ namespace Ddeboer\Imap\Search\Text;
  * Represents a keyword text contains condition. Messages must have a keyword
  * matching the specified text in order to match the condition.
  */
-class Keyword extends Text
+final class Keyword extends AbstractText
 {
     /**
      * Returns the keyword that the condition represents.
      *
      * @return string
      */
-    public function getKeyword(): string
+    protected function getKeyword(): string
     {
         return 'KEYWORD';
     }

--- a/src/Search/Text/Subject.php
+++ b/src/Search/Text/Subject.php
@@ -8,14 +8,14 @@ namespace Ddeboer\Imap\Search\Text;
  * Represents a subject contains condition. Messages must have a subject
  * containing the specified text in order to match the condition.
  */
-class Subject extends Text
+final class Subject extends AbstractText
 {
     /**
      * Returns the keyword that the condition represents.
      *
      * @return string
      */
-    public function getKeyword(): string
+    protected function getKeyword(): string
     {
         return 'SUBJECT';
     }

--- a/src/Search/Text/Text.php
+++ b/src/Search/Text/Text.php
@@ -8,14 +8,14 @@ namespace Ddeboer\Imap\Search\Text;
  * Represents a message text contains condition. Messages must contain the
  * specified text in order to match the condition.
  */
-class Text extends AbstractText
+final class Text extends AbstractText
 {
     /**
      * Returns the keyword that the condition represents.
      *
      * @return string
      */
-    public function getKeyword(): string
+    protected function getKeyword(): string
     {
         return 'TEXT';
     }

--- a/src/Search/Text/Unkeyword.php
+++ b/src/Search/Text/Unkeyword.php
@@ -8,14 +8,14 @@ namespace Ddeboer\Imap\Search\Text;
  * Represents a keyword text does not contain condition. Messages must not have
  * a keyword matching the specified text in order to match the condition.
  */
-class Unkeyword extends Text
+final class Unkeyword extends Text
 {
     /**
      * Returns the keyword that the condition represents.
      *
      * @return string
      */
-    public function getKeyword(): string
+    protected function getKeyword(): string
     {
         return 'UNKEYWORD';
     }

--- a/src/SearchExpression.php
+++ b/src/SearchExpression.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Ddeboer\Imap;
 
-use Ddeboer\Imap\Search\AbstractCondition;
+use Ddeboer\Imap\Search\ConditionInterface;
 
 /**
  * Defines a search expression that can be used to look up email messages.
  */
-class SearchExpression
+final class SearchExpression
 {
     /**
      * The conditions that together represent the expression.
@@ -25,7 +25,7 @@ class SearchExpression
      *
      * @return SearchExpression
      */
-    public function addCondition(AbstractCondition $condition): self
+    public function addCondition(ConditionInterface $condition): self
     {
         $this->conditions[] = $condition;
 
@@ -37,8 +37,12 @@ class SearchExpression
      *
      * @return string
      */
-    public function __toString(): string
+    public function toString(): string
     {
-        return implode(' ', $this->conditions);
+        $conditions = array_map(function (ConditionInterface $condition) {
+            return $condition->toString();
+        }, $this->conditions);
+
+        return implode(' ', $conditions);
     }
 }


### PR DESCRIPTION
Reference: http://phpsadness.com/sad/14

- [x] Introduce `Search\ConditionInterface`
- [x] Typehint against `Search\ConditionInterface`
- [x] Move existing search conditions from `__toString()` to `toString()`
- [x] Typehint `DateTimeInterface` istead of `DateTime`

### BC Breaks

1. Signature of `Ddeboer\Imap\Search\AbstractCondition` changed.
1. Introduced `Ddeboer\Imap\Search\ConditionInterface` to let users implement their own Conditions without inheritance.