### PR TITLE
SearchExpression is a Search\ConditionInterface

### DIFF
--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ddeboer\Imap;
 
 use Ddeboer\Imap\Exception\Exception;
+use Ddeboer\Imap\Search\ConditionInterface;
 
 /**
  * An IMAP mailbox (commonly referred to as a 'folder')
@@ -84,11 +85,11 @@ class Mailbox implements \Countable, \IteratorAggregate
     /**
      * Get message ids
      *
-     * @param SearchExpression $search Search expression (optional)
+     * @param ConditionInterface $search Search expression (optional)
      *
      * @return Message[]|MessageIterator
      */
-    public function getMessages(SearchExpression $search = null): MessageIterator
+    public function getMessages(ConditionInterface $search = null): MessageIterator
     {
         $this->init();
 

--- a/src/SearchExpression.php
+++ b/src/SearchExpression.php
@@ -9,7 +9,7 @@ use Ddeboer\Imap\Search\ConditionInterface;
 /**
  * Defines a search expression that can be used to look up email messages.
  */
-final class SearchExpression
+final class SearchExpression implements ConditionInterface
 {
     /**
      * The conditions that together represent the expression.
@@ -23,7 +23,7 @@ final class SearchExpression
      *
      * @param AbstractCondition $condition the condition to be added
      *
-     * @return SearchExpression
+     * @return self
      */
     public function addCondition(ConditionInterface $condition): self
     {

--- a/tests/MailboxTest.php
+++ b/tests/MailboxTest.php
@@ -86,9 +86,8 @@ class MailboxTest extends AbstractTest
         $this->createTestMessage($this->mailbox, 'Result', 'Contents');
 
         $search = new SearchExpression();
-        $search->addCondition(new To('me@here.com'))
-            ->addCondition(new Body('Contents'))
-        ;
+        $search->addCondition(new To('me@here.com'));
+        $search->addCondition(new Body('Contents'));
 
         $messages = $this->mailbox->getMessages($search);
         $this->assertCount(1, $messages);
@@ -97,9 +96,7 @@ class MailboxTest extends AbstractTest
 
     public function testSearchNoResults()
     {
-        $search = new SearchExpression();
-        $search->addCondition(new To('nope@nope.com'));
-        $this->assertCount(0, $this->mailbox->getMessages($search));
+        $this->assertCount(0, $this->mailbox->getMessages(new To('nope@nope.com')));
     }
 
     public function testDelete()


### PR DESCRIPTION
With the Decorator pattern we can move the `SearchExpression` to be a composition of other `Search\ConditionInterface`, and `Mailbox` can directly typehing `Search\ConditionInterface`.

### BC Breaks

_None_