### PR TITLE
Mailbox: only UTF-8 names

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
     "require": {
         "php": "^7.0",
         "ext-imap": "*",
+        "ext-mbstring": "*",
         "ddeboer/transcoder": "~1"
     },
     "require-dev": {
-        "ext-mbstring": "*",
         "ext-iconv": "*",
         "phpunit/phpunit": "^5.7",
         "friendsofphp/php-cs-fixer": "^2.6"

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -145,7 +145,7 @@ class Connection implements \Countable
      */
     public function createMailbox(string $name): Mailbox
     {
-        if (false === imap_createmailbox($this->getResource(), $this->server . imap_utf7_encode($name))) {
+        if (false === imap_createmailbox($this->getResource(), $this->server . mb_convert_encoding($name, 'UTF7-IMAP', 'UTF-8'))) {
             throw new Exception(sprintf(
                 'Can not create "%s" mailbox at "%s"',
                 $name,
@@ -184,7 +184,7 @@ class Connection implements \Countable
         $this->mailboxNames = [];
         $mailboxesInfo = imap_getmailboxes($this->getResource(), $this->server, '*');
         foreach ($mailboxesInfo as $mailboxInfo) {
-            $name = imap_utf7_decode(str_replace($this->server, '', $mailboxInfo->name));
+            $name = mb_convert_encoding(str_replace($this->server, '', $mailboxInfo->name), 'UTF-8', 'UTF7-IMAP');
             $this->mailboxNames[$name] = $mailboxInfo;
         }
     }

--- a/tests/AbstractTest.php
+++ b/tests/AbstractTest.php
@@ -12,7 +12,7 @@ abstract class AbstractTest extends PHPUnit_Framework_TestCase
 {
     const IMAP_FLAGS = '/imap/ssl/novalidate-cert';
 
-    const NON_PRINTABLE_ASCII = 'A_è_π_Z_';
+    const SPECIAL_CHARS = 'A_\\|!"£$%&()=?àèìòùÀÈÌÒÙ<>-@#[]{}_ß_б_π_€_✔_你_يد_Z_';
 
     final protected function getConnection()
     {
@@ -33,7 +33,7 @@ abstract class AbstractTest extends PHPUnit_Framework_TestCase
 
     final protected function createMailbox()
     {
-        $this->mailboxName = uniqid('mailbox_' . self::NON_PRINTABLE_ASCII);
+        $this->mailboxName = uniqid('mailbox_' . self::SPECIAL_CHARS);
 
         return $this->getConnection()->createMailbox($this->mailboxName);
     }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -90,15 +90,15 @@ class ConnectionTest extends AbstractTest
 
     public function testEscapesMailboxNames()
     {
-        $this->assertInstanceOf(Mailbox::class, $this->getConnection()->createMailbox(uniqid(self::NON_PRINTABLE_ASCII)));
+        $this->assertInstanceOf(Mailbox::class, $this->getConnection()->createMailbox(uniqid(self::SPECIAL_CHARS)));
     }
 
     public function testCustomExceptionOnInvalidMailboxName()
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessageRegExp('/Mailbox name is not valid mUTF-7/');
+        $this->expectExceptionMessageRegExp('/CANNOT/');
 
-        $this->assertInstanceOf(Mailbox::class, $this->getConnection()->createMailbox(uniqid('A_€_')));
+        $this->assertInstanceOf(Mailbox::class, $this->getConnection()->createMailbox(uniqid("\t")));
     }
 
     public function testGetInvalidMailbox()

--- a/tests/MailboxTest.php
+++ b/tests/MailboxTest.php
@@ -38,7 +38,7 @@ class MailboxTest extends AbstractTest
     {
         $this->assertContains(\getenv('IMAP_SERVER_PORT'), $this->mailbox->getFullEncodedName());
         $this->assertNotContains($this->mailboxName, $this->mailbox->getFullEncodedName());
-        $this->assertContains(imap_utf7_encode($this->mailboxName), $this->mailbox->getFullEncodedName());
+        $this->assertContains(mb_convert_encoding($this->mailboxName, 'UTF7-IMAP', 'UTF-8'), $this->mailbox->getFullEncodedName());
     }
 
     public function testGetAttributes()


### PR DESCRIPTION
Closes https://github.com/ddeboer/imap/issues/185

- [x] Move from `imap_utf7_(encode|decode)` to `mb_convert_encoding`

### BC Breaks

`ext-mbstring` is now required