### PR TITLE
Remove misleading Mailbox::expunge()

### DIFF
--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -159,16 +159,6 @@ class Mailbox implements \Countable, \IteratorAggregate
     }
 
     /**
-     * Delete all messages marked for deletion
-     *
-     * @return Mailbox
-     */
-    public function expunge()
-    {
-        $this->connection->expunge();
-    }
-
-    /**
      * Add a message to the mailbox
      *
      * @param string $message

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -11,7 +11,6 @@ use Zend\Mime\Mime;
 
 /**
  * @covers \Ddeboer\Imap\Connection::expunge
- * @covers \Ddeboer\Imap\Mailbox::expunge
  * @covers \Ddeboer\Imap\Message
  * @covers \Ddeboer\Imap\MessageIterator
  * @covers \Ddeboer\Imap\Message\Attachment
@@ -221,7 +220,7 @@ class MessageTest extends AbstractTest
 
         $message = $this->mailbox->getMessage(3);
         $message->delete();
-        $this->mailbox->expunge();
+        $this->getConnection()->expunge();
 
         $this->assertCount(2, $this->mailbox);
         foreach ($this->mailbox->getMessages() as $message) {


### PR DESCRIPTION
Consider this code:
```php
$mailboxOne = $connection->getMailbox('one');
$mailboxTwo = $connection->getMailbox('two');

$mailboxOne->getMessages()[0]->delete();
$mailboxTwo->getMessages()[0]->delete();

$mailboxOne->expunge();
```
A user can think that only the message of the first mailbox is deleted, while in reality both are deleted.