### PR TITLE
Fix imap_mail_move behaviour and test it

### DIFF
--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -41,6 +41,16 @@ class Mailbox implements \Countable, \IteratorAggregate
     }
 
     /**
+     * Get mailbox encoded path
+     *
+     * @return string
+     */
+    public function getEncodedName(): string
+    {
+        return preg_replace('/^{.+}/', '', $this->info->name);
+    }
+
+    /**
      * Get mailbox encoded full name
      *
      * @return string

--- a/src/Message.php
+++ b/src/Message.php
@@ -390,20 +390,16 @@ class Message extends Message\Part
      * @param Mailbox $mailbox
      *
      * @throws MessageMoveException
-     *
-     * @return Message
      */
-    public function move(Mailbox $mailbox): self
+    public function move(Mailbox $mailbox)
     {
-        if (!imap_mail_move($this->stream, $this->messageNumber, $mailbox->getName(), \CP_UID)) {
+        if (!imap_mail_move($this->stream, (string) $this->messageNumber, $mailbox->getEncodedName(), \CP_UID)) {
             throw new MessageMoveException(sprintf(
                 'Message "%s" cannot be moved to "%s"',
                 $this->messageNumber,
                 $mailbox->getName()
             ));
         }
-
-        return $this;
     }
 
     /**

--- a/tests/AbstractTest.php
+++ b/tests/AbstractTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ddeboer\Imap\Tests;
 
+use Ddeboer\Imap\Connection;
 use Ddeboer\Imap\Mailbox;
 use Ddeboer\Imap\Server;
 use PHPUnit_Framework_TestCase;
@@ -14,9 +15,9 @@ abstract class AbstractTest extends PHPUnit_Framework_TestCase
 {
     const IMAP_FLAGS = '/imap/ssl/novalidate-cert';
 
-    const SPECIAL_CHARS = 'A_\\|!"£$%&()=?àèìòùÀÈÌÒÙ<>-@#[]{}_ß_б_π_€_✔_你_يد_Z_';
+    const SPECIAL_CHARS = 'A_\\|!"£$%&()=?àèìòùÀÈÌÒÙ<>-@#[]_ß_б_π_€_✔_你_يد_Z_';
 
-    final protected function getConnection()
+    final protected function getConnection(): Connection
     {
         static $connection;
         if (null === $connection) {
@@ -26,18 +27,19 @@ abstract class AbstractTest extends PHPUnit_Framework_TestCase
         return $connection;
     }
 
-    final protected function createConnection()
+    final protected function createConnection(): Connection
     {
         $server = new Server(\getenv('IMAP_SERVER_NAME'), \getenv('IMAP_SERVER_PORT'), self::IMAP_FLAGS);
 
         return $server->authenticate(\getenv('IMAP_USERNAME'), \getenv('IMAP_PASSWORD'));
     }
 
-    final protected function createMailbox()
+    final protected function createMailbox(Connection $connection = null): Mailbox
     {
+        $connection = $connection ?? $this->getConnection();
         $this->mailboxName = uniqid('mailbox_' . self::SPECIAL_CHARS);
 
-        return $this->getConnection()->createMailbox($this->mailboxName);
+        return $connection->createMailbox($this->mailboxName);
     }
 
     final protected function createTestMessage(
@@ -78,7 +80,7 @@ abstract class AbstractTest extends PHPUnit_Framework_TestCase
         $mailbox->addMessage($messageString);
     }
 
-    final protected function getFixture($fixture)
+    final protected function getFixture($fixture): string
     {
         return file_get_contents(sprintf('%s/fixtures/%s.eml', __DIR__, $fixture));
     }

--- a/tests/MailboxTest.php
+++ b/tests/MailboxTest.php
@@ -37,6 +37,7 @@ class MailboxTest extends AbstractTest
         $this->assertContains(\getenv('IMAP_SERVER_PORT'), $this->mailbox->getFullEncodedName());
         $this->assertNotContains($this->mailboxName, $this->mailbox->getFullEncodedName());
         $this->assertContains(mb_convert_encoding($this->mailboxName, 'UTF7-IMAP', 'UTF-8'), $this->mailbox->getFullEncodedName());
+        $this->assertNotContains(\getenv('IMAP_SERVER_PORT'), $this->mailbox->getEncodedName());
     }
 
     public function testGetAttributes()

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -228,6 +228,23 @@ class MessageTest extends AbstractTest
         }
     }
 
+    public function testMove()
+    {
+        $mailboxOne = $this->createMailbox();
+        $mailboxTwo = $this->createMailbox();
+        $this->createTestMessage($mailboxOne, 'Message A');
+
+        $this->assertCount(1, $mailboxOne);
+        $this->assertCount(0, $mailboxTwo);
+
+        $message = $mailboxOne->getMessage(1);
+        $message->move($mailboxTwo);
+        $this->getConnection()->expunge();
+
+        $this->assertCount(0, $mailboxOne);
+        $this->assertCount(1, $mailboxTwo);
+    }
+
     /**
      * @dataProvider getAttachmentFixture
      */


### PR DESCRIPTION
Related to https://github.com/ddeboer/imap/issues/73

It seems that `imap_mail_move` needs the encoded mail path, but without the server part (my gosh).