### PR TITLE
Exclude HTML from allowed attachment subtype

### DIFF
--- a/src/Message/Part.php
+++ b/src/Message/Part.php
@@ -312,9 +312,10 @@ class Part implements \RecursiveIterator
     {
         // Attachment with correct Content-Disposition header
         if (isset($part->disposition)) {
-            if (('attachment' === strtolower($part->disposition)
-                || 'inline' === strtolower($part->disposition))
-            && strtoupper($part->subtype) != 'PLAIN'
+            if (
+                    ('attachment' === strtolower($part->disposition) || 'inline' === strtolower($part->disposition))
+                && strtoupper($part->subtype) !== self::SUBTYPE_PLAIN
+                && strtoupper($part->subtype) !== self::SUBTYPE_HTML
             ) {
                 return true;
             }
@@ -323,9 +324,7 @@ class Part implements \RecursiveIterator
         // Attachment without Content-Disposition header
         if (isset($part->parameters)) {
             foreach ($part->parameters as $parameter) {
-                if ('name' === strtolower($parameter->attribute)
-                    || 'filename' === strtolower($parameter->attribute)
-                ) {
+                if ('name' === strtolower($parameter->attribute) || 'filename' === strtolower($parameter->attribute)) {
                     return true;
                 }
             }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -478,4 +478,17 @@ class MessageTest extends AbstractTest
 
         $this->assertCount(1, $message->getAttachments());
     }
+
+    /**
+     * @see https://github.com/ddeboer/imap/issues/142
+     */
+    public function testIssue142()
+    {
+        $fixture = $this->getFixture('issue_142');
+        $this->mailbox->addMessage($fixture);
+
+        $message = $this->mailbox->getMessage(1);
+
+        $this->assertCount(1, $message->getAttachments());
+    }
 }

--- a/tests/fixtures/issue_142.eml
+++ b/tests/fixtures/issue_142.eml
@@ -1,0 +1,23 @@
+From: mytaxi Payment <somesender@sending.net>
+To: anonym@anonym.com
+Message-ID: <00000144c8445931-be533ff5-c8b9-4257-a4cd-3c280b2f3854-000000@email.amazonses.com>
+Subject: Ihre mytaxi Quittung (49M6J)
+MIME-Version: 1.0
+Content-Type: multipart/mixed; 
+	boundary="----=_Part_27875_991041197.1394929323292"
+Date: Sun, 16 Mar 2014 00:22:06 +0000
+
+------=_Part_27875_991041197.1394929323292
+Content-Type: text/html; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: inline
+
+<body>Hi</body>
+
+------=_Part_27875_991041197.1394929323292
+Content-Type: application/pdf
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename=2014-03-49M6J.pdf
+
+XS9JbmZvIDE3IDAgUi9TaXplIDE4Pj4Kc3RhcnR4cmVmCjE0MDIxMQolJUVPRgo=
+------=_Part_27875_991041197.1394929323292--


### PR DESCRIPTION
Fix for https://github.com/ddeboer/imap/issues/142