### PR TITLE
Always keep unseen: remove keepUnseen, add markAsSeen

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -19,11 +19,6 @@ class Message extends Message\AbstractMessage
     private $attachments;
 
     /**
-     * @var bool
-     */
-    private $keepUnseen = false;
-
-    /**
      * Constructor
      *
      * @param resource $stream        IMAP stream
@@ -84,11 +79,11 @@ class Message extends Message\AbstractMessage
      *
      * @return string the raw message
      */
-    public function getRawMessage(bool $keepUnseen = false): string
+    public function getRawMessage(): string
     {
         $this->clearHeaders();
 
-        return imap_fetchbody($this->stream, $this->messageNumber, '', \FT_UID | ($keepUnseen ? \FT_PEEK : null));
+        return imap_fetchbody($this->stream, $this->messageNumber, '', \FT_UID | \FT_PEEK);
     }
 
     /**
@@ -118,39 +113,21 @@ class Message extends Message\AbstractMessage
     }
 
     /**
-     * Prevent the message from being marked as seen
-     *
-     * Defaults to true, so messages that are read will be still marked as unseen.
-     *
-     * @param bool $bool
-     *
-     * @return Message
-     */
-    public function keepUnseen(bool $bool = true): self
-    {
-        $this->keepUnseen = $bool;
-
-        return $this;
-    }
-
-    /**
      * Get raw part content
-     *
-     * @param mixed $keepUnseen
      *
      * @return string
      */
-    public function getContent(bool $keepUnseen = false): string
+    public function getContent(): string
     {
         // Null headers, so subsequent calls to getHeaders() will return
         // updated seen flag
         $this->clearHeaders();
 
-        return $this->doGetContent($this->keepUnseen ? $this->keepUnseen : $keepUnseen);
+        return $this->doGetContent();
     }
 
     /**
-     * Get message unseen flag value (from headers)
+     * Get message recent flag value (from headers)
      *
      * @return string
      */
@@ -217,6 +194,16 @@ class Message extends Message\AbstractMessage
     public function isSeen(): bool
     {
         return 'N' !== $this->getHeaders()->get('recent') && 'U' !== $this->getHeaders()->get('unseen');
+    }
+
+    /**
+     * Mark message as seen
+     *
+     * @return bool
+     */
+    public function maskAsSeen(): bool
+    {
+        return $this->setFlag('\\Seen');
     }
 
     /**

--- a/src/Message/AbstractMessage.php
+++ b/src/Message/AbstractMessage.php
@@ -11,11 +11,6 @@ abstract class AbstractMessage extends Part
     private $attachments;
 
     /**
-     * @var bool
-     */
-    private $keepUnseen = false;
-
-    /**
      * Get raw message headers
      *
      * @return string
@@ -158,13 +153,13 @@ abstract class AbstractMessage extends Part
         $iterator = new \RecursiveIteratorIterator($this, \RecursiveIteratorIterator::SELF_FIRST);
         foreach ($iterator as $part) {
             if (self::SUBTYPE_HTML === $part->getSubtype()) {
-                return $part->getDecodedContent($this->keepUnseen);
+                return $part->getDecodedContent();
             }
         }
 
         // If message has no parts and is HTML, return content of message itself.
         if (self::SUBTYPE_HTML === $this->getSubtype()) {
-            return $this->getDecodedContent($this->keepUnseen);
+            return $this->getDecodedContent();
         }
 
         return;
@@ -180,13 +175,13 @@ abstract class AbstractMessage extends Part
         $iterator = new \RecursiveIteratorIterator($this, \RecursiveIteratorIterator::SELF_FIRST);
         foreach ($iterator as $part) {
             if (self::SUBTYPE_PLAIN === $part->getSubtype()) {
-                return $part->getDecodedContent($this->keepUnseen);
+                return $part->getDecodedContent();
             }
         }
 
         // If message has no parts, return content of message itself.
         if (self::SUBTYPE_PLAIN === $this->getSubtype()) {
-            return $this->getDecodedContent($this->keepUnseen);
+            return $this->getDecodedContent();
         }
 
         return;

--- a/src/Message/Part.php
+++ b/src/Message/Part.php
@@ -153,14 +153,12 @@ class Part implements \RecursiveIterator
     /**
      * Get raw part content
      *
-     * @param mixed $keepUnseen
-     *
      * @return string
      */
-    public function getContent(bool $keepUnseen = false): string
+    public function getContent(): string
     {
         if (null === $this->content) {
-            $this->content = $this->doGetContent($keepUnseen);
+            $this->content = $this->doGetContent();
         }
 
         return $this->content;
@@ -169,14 +167,12 @@ class Part implements \RecursiveIterator
     /**
      * Get decoded part content
      *
-     * @param mixed $keepUnseen
-     *
      * @return string
      */
-    public function getDecodedContent(bool $keepUnseen = false): string
+    public function getDecodedContent(): string
     {
         if (null === $this->decodedContent) {
-            $content = $this->getContent($keepUnseen);
+            $content = $this->getContent();
             if (self::ENCODING_BASE64 === $this->getEncoding()) {
                 $content = base64_decode($content);
             } elseif (self::ENCODING_QUOTED_PRINTABLE === $this->getEncoding()) {
@@ -302,19 +298,15 @@ class Part implements \RecursiveIterator
     /**
      * Get raw message content
      *
-     * @param bool $keepUnseen Whether to keep the message unseen.
-     *                         Default behaviour is set set the seen flag when
-     *                         getting content.
-     *
      * @return string
      */
-    protected function doGetContent(bool $keepUnseen = false)
+    protected function doGetContent()
     {
         return imap_fetchbody(
             $this->stream,
             $this->messageNumber,
             (string) ($this->partNumber ?: '1'),
-            \FT_UID | ($keepUnseen ? \FT_PEEK : null)
+            \FT_UID | \FT_PEEK
         );
     }
 

--- a/tests/EmbeddedMessageTest.php
+++ b/tests/EmbeddedMessageTest.php
@@ -33,6 +33,8 @@ final class EmbeddedMessageTest extends AbstractTest
         $this->assertEquals('demo', $embeddedMessage->getSubject());
         $this->assertEquals('demo-from@cerstor.cz', $embeddedMessage->getFrom()->getFullAddress());
         $this->assertEquals('demo-to@cerstor.cz', $embeddedMessage->getTo()[0]->getFullAddress());
+
+        $this->assertFalse($message->isSeen());
     }
 
     public function testEmbeddedAttachment()

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -36,23 +36,18 @@ class MessageTest extends AbstractTest
         $this->mailbox = $this->createMailbox();
     }
 
-    public function testKeepUnseen()
+    public function testAlwaysKeepUnseen()
     {
         $this->createTestMessage($this->mailbox, 'Message A');
-        $this->createTestMessage($this->mailbox, 'Message B');
-        $this->createTestMessage($this->mailbox, 'Message C');
 
         $message = $this->mailbox->getMessage(1);
         $this->assertFalse($message->isSeen());
 
         $message->getBodyText();
+        $this->assertFalse($message->isSeen());
+
+        $message->maskAsSeen();
         $this->assertTrue($message->isSeen());
-
-        $message = $this->mailbox->getMessage(2);
-        $this->assertFalse($message->isSeen());
-
-        $message->keepUnseen()->getBodyText();
-        $this->assertFalse($message->isSeen());
     }
 
     public function testFlags()
@@ -214,6 +209,8 @@ class MessageTest extends AbstractTest
         $this->assertEquals('No-address', $cc[1]->getMailbox());
 
         $this->assertCount(0, $message->getReturnPath());
+
+        $this->assertFalse($message->isSeen());
     }
 
     public function testBcc()
@@ -274,6 +271,8 @@ class MessageTest extends AbstractTest
 
         $this->assertCount(1, $mailboxOne);
         $this->assertCount(1, $mailboxTwo);
+
+        $this->assertFalse($message->isSeen());
     }
 
     /**
@@ -295,6 +294,8 @@ class MessageTest extends AbstractTest
             $attachment->getFilename()
         );
         $this->assertNull($attachment->getSize());
+
+        $this->assertFalse($message->isSeen());
     }
 
     public function getAttachmentFixture(): array
@@ -407,6 +408,8 @@ class MessageTest extends AbstractTest
         $expectedHeaders = implode("\r\n", $expectedHeaders);
 
         $this->assertSame($expectedHeaders, $message->getRawHeaders());
+
+        $this->assertFalse($message->isSeen());
     }
 
     /**
@@ -424,6 +427,8 @@ class MessageTest extends AbstractTest
         $this->assertArrayHasKey('from', $headers);
         $this->assertArrayHasKey('date', $headers);
         $this->assertArrayHasKey('recent', $headers);
+
+        $this->assertFalse($message->isSeen());
     }
 
     public function testSetFlags()
@@ -490,6 +495,8 @@ class MessageTest extends AbstractTest
         }
 
         $this->assertCount(2, $parts);
+
+        $this->assertFalse($message->isSeen());
     }
 
     public function testGetRawMessage()
@@ -499,10 +506,7 @@ class MessageTest extends AbstractTest
 
         $message = $this->mailbox->getMessage(1);
 
-        $this->assertSame($fixture, $message->getRawMessage(true));
-        $this->assertFalse($message->isSeen());
         $this->assertSame($fixture, $message->getRawMessage());
-        $this->assertTrue($message->isSeen());
     }
 
     public function testAttachmentOnlyEmail()


### PR DESCRIPTION
Correct propagation of `$keepUnseen` flag is too complex.
By default from now every operation will retain unseen flag. If you need to mark a mail as seen, use the explicit method.

### BC break

1. Removed `Ddeboer\Imap\Message::keepUnseen`
1. Added `Ddeboer\Imap\Message::markAsSeen`
1. Removed `Ddeboer\Imap\Message::getRawMessage` `$keepUnseen` argument
1. Removed `Ddeboer\Imap\Message::getContent` `$keepUnseen` argument
1. Removed `Ddeboer\Imap\Message::getDecodedContent` `$keepUnseen` argument