### PR TITLE
Wrap imap resource to periodically check its status

### DIFF
--- a/src/ImapResource.php
+++ b/src/ImapResource.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ddeboer\Imap;
+
+use Ddeboer\Imap\Exception\InvalidResourceException;
+
+/**
+ * An imap resource stream.
+ */
+final class ImapResource implements ImapResourceInterface
+{
+    private $resource;
+
+    /**
+     * Constructor.
+     *
+     * @param resource $resource
+     */
+    public function __construct($resource)
+    {
+        $this->resource = $resource;
+    }
+
+    /**
+     * Get IMAP resource stream.
+     *
+     * @throws InvalidResourceException
+     *
+     * @return resource
+     */
+    public function getStream()
+    {
+        if (false === \is_resource($this->resource) || 'imap' !== \get_resource_type($this->resource)) {
+            throw new InvalidResourceException('Supplied resource is not a valid imap resource');
+        }
+
+        return $this->resource;
+    }
+}

--- a/src/ImapResourceInterface.php
+++ b/src/ImapResourceInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ddeboer\Imap;
+
+interface ImapResourceInterface
+{
+    /**
+     * Get IMAP resource stream.
+     *
+     * @return resource
+     */
+    public function getStream();
+}

--- a/src/Message/Attachment.php
+++ b/src/Message/Attachment.php
@@ -54,6 +54,6 @@ final class Attachment extends Part
             ));
         }
 
-        return new EmbeddedMessage($this->stream, $this->messageNumber, $this->partNumber, $this->structure->parts[0]);
+        return new EmbeddedMessage($this->resource, $this->messageNumber, $this->partNumber, $this->structure->parts[0]);
     }
 }

--- a/src/Message/EmbeddedMessage.php
+++ b/src/Message/EmbeddedMessage.php
@@ -47,7 +47,7 @@ final class EmbeddedMessage extends AbstractMessage
     public function getRawMessage(): string
     {
         if (null === $this->rawMessage) {
-            $this->rawMessage = \imap_fetchbody($this->stream, $this->messageNumber, $this->partNumber, \FT_UID | \FT_PEEK);
+            $this->rawMessage = \imap_fetchbody($this->resource->getStream(), $this->messageNumber, $this->partNumber, \FT_UID | \FT_PEEK);
         }
 
         return $this->rawMessage;

--- a/src/MessageIterator.php
+++ b/src/MessageIterator.php
@@ -6,17 +6,17 @@ namespace Ddeboer\Imap;
 
 final class MessageIterator extends \ArrayIterator
 {
-    private $stream;
+    private $resource;
 
     /**
      * Constructor.
      *
-     * @param \resource $stream         IMAP stream
-     * @param array     $messageNumbers Array of message numbers
+     * @param ImapResourceInterface $resource       IMAP resource
+     * @param array                 $messageNumbers Array of message numbers
      */
-    public function __construct($stream, array $messageNumbers)
+    public function __construct(ImapResourceInterface $resource, array $messageNumbers)
     {
-        $this->stream = $stream;
+        $this->resource = $resource;
 
         parent::__construct($messageNumbers);
     }
@@ -28,6 +28,6 @@ final class MessageIterator extends \ArrayIterator
      */
     public function current(): Message
     {
-        return new Message($this->stream, parent::current());
+        return new Message($this->resource, parent::current());
     }
 }

--- a/src/Server.php
+++ b/src/Server.php
@@ -96,7 +96,7 @@ final class Server
         \imap_errors();
         \imap_alerts();
 
-        return new Connection($resource, $connection);
+        return new Connection(new ImapResource($resource), $connection);
     }
 
     /**

--- a/tests/MailboxTest.php
+++ b/tests/MailboxTest.php
@@ -83,7 +83,8 @@ class MailboxTest extends AbstractTest
 
     public function testDelete()
     {
-        $this->mailbox->delete();
+        $connection = $this->getConnection();
+        $connection->deleteMailbox($this->mailbox);
 
         $this->expectException(ReopenMailboxException::class);
 

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -16,7 +16,7 @@ class ServerTest extends AbstractTest
     {
         $connection = $this->getConnection();
 
-        $check = \imap_check($connection->getResource());
+        $check = \imap_check($connection->getResource()->getStream());
 
         $this->assertInstanceOf(\stdClass::class, $check);
     }


### PR DESCRIPTION
- [x] Wrap imap resource to check its status every time it's used
- [x] Make every `imap_*` call use the wrap API
- [x] Check at every call that the imap resource is still valid

### BC break

1. Removed `Ddeboer\Imap\Mailbox::delete` that it's just a shortcut for `Ddeboer\Imap\Connection::deleteMailbox` since we don't have anymore the `Connection` instance