### PR TITLE
Add mocking ability through Interfaces

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -67,7 +67,7 @@ final class Connection implements ConnectionInterface
     /**
      * Get a list of mailboxes (also known as folders).
      *
-     * @return Mailbox[]
+     * @return MailboxInterface[]
      */
     public function getMailboxes(): array
     {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -11,7 +11,7 @@ use Ddeboer\Imap\Exception\MailboxDoesNotExistException;
 /**
  * A connection to an IMAP server that is authenticated for a user.
  */
-final class Connection implements \Countable
+final class Connection implements ConnectionInterface
 {
     private $resource;
     private $server;
@@ -104,9 +104,9 @@ final class Connection implements \Countable
      *
      * @throws MailboxDoesNotExistException If mailbox does not exist
      *
-     * @return Mailbox
+     * @return MailboxInterface
      */
-    public function getMailbox(string $name): Mailbox
+    public function getMailbox(string $name): MailboxInterface
     {
         if (false === $this->hasMailbox($name)) {
             throw new MailboxDoesNotExistException(\sprintf('Mailbox name "%s" does not exist', $name));
@@ -132,9 +132,9 @@ final class Connection implements \Countable
      *
      * @throws CreateMailboxException
      *
-     * @return Mailbox
+     * @return MailboxInterface
      */
-    public function createMailbox(string $name): Mailbox
+    public function createMailbox(string $name): MailboxInterface
     {
         if (false === \imap_createmailbox($this->resource->getStream(), $this->server . \mb_convert_encoding($name, 'UTF7-IMAP', 'UTF-8'))) {
             throw new CreateMailboxException(\sprintf('Can not create "%s" mailbox at "%s"', $name, $this->server));
@@ -148,11 +148,11 @@ final class Connection implements \Countable
     /**
      * Create mailbox.
      *
-     * @param Mailbox
+     * @param MailboxInterface
      *
      * @throws DeleteMailboxException
      */
-    public function deleteMailbox(Mailbox $mailbox)
+    public function deleteMailbox(MailboxInterface $mailbox)
     {
         if (false === \imap_deletemailbox($this->resource->getStream(), $mailbox->getFullEncodedName())) {
             throw new DeleteMailboxException(\sprintf('Mailbox "%s" could not be deleted', $mailbox->getName()));

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ddeboer\Imap;
+
+/**
+ * A connection to an IMAP server that is authenticated for a user.
+ */
+interface ConnectionInterface extends \Countable
+{
+    /**
+     * Get IMAP resource.
+     *
+     * @return ImapResourceInterface
+     */
+    public function getResource(): ImapResourceInterface;
+
+    /**
+     * Delete all messages marked for deletion.
+     *
+     * @return bool
+     */
+    public function expunge(): bool;
+
+    /**
+     * Close connection.
+     *
+     * @param int $flag
+     *
+     * @return bool
+     */
+    public function close(int $flag = 0): bool;
+
+    /**
+     * Get a list of mailboxes (also known as folders).
+     *
+     * @return Mailbox[]
+     */
+    public function getMailboxes(): array;
+
+    /**
+     * Check that a mailbox with the given name exists.
+     *
+     * @param string $name Mailbox name
+     *
+     * @return bool
+     */
+    public function hasMailbox(string $name): bool;
+
+    /**
+     * Get a mailbox by its name.
+     *
+     * @param string $name Mailbox name
+     *
+     * @return MailboxInterface
+     */
+    public function getMailbox(string $name): MailboxInterface;
+
+    /**
+     * Create mailbox.
+     *
+     * @param $name
+     *
+     * @return MailboxInterface
+     */
+    public function createMailbox(string $name): MailboxInterface;
+
+    /**
+     * Create mailbox.
+     *
+     * @param MailboxInterface
+     */
+    public function deleteMailbox(MailboxInterface $mailbox);
+}

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -35,7 +35,7 @@ interface ConnectionInterface extends \Countable
     /**
      * Get a list of mailboxes (also known as folders).
      *
-     * @return Mailbox[]
+     * @return MailboxInterface[]
      */
     public function getMailboxes(): array;
 

--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -12,7 +12,7 @@ use Ddeboer\Imap\Search\LogicalOperator\All;
 /**
  * An IMAP mailbox (commonly referred to as a 'folder').
  */
-final class Mailbox implements \Countable, \IteratorAggregate
+final class Mailbox implements MailboxInterface
 {
     private $resource;
     private $name;
@@ -75,7 +75,7 @@ final class Mailbox implements \Countable, \IteratorAggregate
     /**
      * Get mailbox delimiter.
      *
-     * @return int
+     * @return string
      */
     public function getDelimiter(): string
     {
@@ -101,7 +101,7 @@ final class Mailbox implements \Countable, \IteratorAggregate
      *
      * @return \stdClass
      */
-    public function getStatus(int $flags = null)
+    public function getStatus(int $flags = null): \stdClass
     {
         $this->init();
 
@@ -113,9 +113,9 @@ final class Mailbox implements \Countable, \IteratorAggregate
      *
      * @param ConditionInterface $search Search expression (optional)
      *
-     * @return Message[]|MessageIterator
+     * @return MessageIteratorInterface
      */
-    public function getMessages(ConditionInterface $search = null, int $sortCriteria = null, bool $descending = false): MessageIterator
+    public function getMessages(ConditionInterface $search = null, int $sortCriteria = null, bool $descending = false): MessageIteratorInterface
     {
         $this->init();
 
@@ -150,9 +150,9 @@ final class Mailbox implements \Countable, \IteratorAggregate
      *
      * @param int $number Message number
      *
-     * @return Message
+     * @return MessageInterface
      */
-    public function getMessage(int $number): Message
+    public function getMessage(int $number): MessageInterface
     {
         $this->init();
 
@@ -162,9 +162,9 @@ final class Mailbox implements \Countable, \IteratorAggregate
     /**
      * Get messages in this mailbox.
      *
-     * @return MessageIterator
+     * @return MessageIteratorInterface
      */
-    public function getIterator(): MessageIterator
+    public function getIterator(): MessageIteratorInterface
     {
         return $this->getMessages();
     }
@@ -176,7 +176,7 @@ final class Mailbox implements \Countable, \IteratorAggregate
      *
      * @return bool
      */
-    public function addMessage($message): bool
+    public function addMessage(string $message): bool
     {
         return \imap_append($this->resource->getStream(), $this->getFullEncodedName(), $message);
     }

--- a/src/MailboxInterface.php
+++ b/src/MailboxInterface.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ddeboer\Imap;
+
+use Ddeboer\Imap\Search\ConditionInterface;
+
+/**
+ * An IMAP mailbox (commonly referred to as a 'folder').
+ */
+interface MailboxInterface extends \Countable, \IteratorAggregate
+{
+    /**
+     * Get mailbox decoded name.
+     *
+     * @return string
+     */
+    public function getName(): string;
+
+    /**
+     * Get mailbox encoded path.
+     *
+     * @return string
+     */
+    public function getEncodedName(): string;
+
+    /**
+     * Get mailbox encoded full name.
+     *
+     * @return string
+     */
+    public function getFullEncodedName(): string;
+
+    /**
+     * Get mailbox attributes.
+     *
+     * @return int
+     */
+    public function getAttributes(): int;
+
+    /**
+     * Get mailbox delimiter.
+     *
+     * @return string
+     */
+    public function getDelimiter(): string;
+
+    /**
+     * Get Mailbox status.
+     *
+     * @param int $flag
+     *
+     * @return \stdClass
+     */
+    public function getStatus(int $flags = null): \stdClass;
+
+    /**
+     * Get message ids.
+     *
+     * @param ConditionInterface $search Search expression (optional)
+     *
+     * @return MessageIteratorInterface
+     */
+    public function getMessages(ConditionInterface $search = null, int $sortCriteria = null, bool $descending = false): MessageIteratorInterface;
+
+    /**
+     * Get a message by message number.
+     *
+     * @param int $number Message number
+     *
+     * @return MessageInterface
+     */
+    public function getMessage(int $number): MessageInterface;
+
+    /**
+     * Get messages in this mailbox.
+     *
+     * @return MessageIteratorInterface
+     */
+    public function getIterator(): MessageIteratorInterface;
+
+    /**
+     * Add a message to the mailbox.
+     *
+     * @param string $message
+     *
+     * @return bool
+     */
+    public function addMessage(string $message): bool;
+}

--- a/src/Message.php
+++ b/src/Message.php
@@ -12,7 +12,7 @@ use Ddeboer\Imap\Exception\MessageStructureException;
 /**
  * An IMAP message (e-mail).
  */
-final class Message extends Message\AbstractMessage
+final class Message extends Message\AbstractMessage implements MessageInterface
 {
     private $headers;
     private $rawHeaders;
@@ -206,11 +206,11 @@ final class Message extends Message\AbstractMessage
     /**
      * Move message to another mailbox.
      *
-     * @param Mailbox $mailbox
+     * @param MailboxInterface $mailbox
      *
      * @throws MessageCopyException
      */
-    public function copy(Mailbox $mailbox)
+    public function copy(MailboxInterface $mailbox)
     {
         // 'deleted' header changed, force to reload headers, would be better to set deleted flag to true on header
         $this->clearHeaders();
@@ -223,11 +223,11 @@ final class Message extends Message\AbstractMessage
     /**
      * Move message to another mailbox.
      *
-     * @param Mailbox $mailbox
+     * @param MailboxInterface $mailbox
      *
      * @throws MessageMoveException
      */
-    public function move(Mailbox $mailbox)
+    public function move(MailboxInterface $mailbox)
     {
         // 'deleted' header changed, force to reload headers, would be better to set deleted flag to true on header
         $this->clearHeaders();

--- a/src/Message/AbstractMessage.php
+++ b/src/Message/AbstractMessage.php
@@ -4,32 +4,11 @@ declare(strict_types=1);
 
 namespace Ddeboer\Imap\Message;
 
-abstract class AbstractMessage extends Part
+abstract class AbstractMessage extends AbstractPart
 {
     private $headers;
     private $rawHeaders;
     private $attachments;
-
-    /**
-     * Get raw message headers.
-     *
-     * @return string
-     */
-    abstract public function getRawHeaders(): string;
-
-    /**
-     * Get the raw message, including all headers, parts, etc. unencoded and unparsed.
-     *
-     * @return string the raw message
-     */
-    abstract public function getRawMessage(): string;
-
-    /**
-     * Get message headers.
-     *
-     * @return Headers
-     */
-    abstract public function getHeaders(): Headers;
 
     /**
      * Get message id.
@@ -190,7 +169,7 @@ abstract class AbstractMessage extends Part
     /**
      * Get attachments (if any) linked to this e-mail.
      *
-     * @return Attachment[]
+     * @return AttachmentInterface[]
      */
     public function getAttachments(): array
     {

--- a/src/Message/AbstractMessage.php
+++ b/src/Message/AbstractMessage.php
@@ -17,7 +17,7 @@ abstract class AbstractMessage extends AbstractPart
      *
      * @return string
      */
-    public function getId(): string
+    final public function getId(): string
     {
         return $this->getHeaders()->get('message_id');
     }
@@ -27,7 +27,7 @@ abstract class AbstractMessage extends AbstractPart
      *
      * @return EmailAddress
      */
-    public function getFrom(): EmailAddress
+    final public function getFrom(): EmailAddress
     {
         return $this->getHeaders()->get('from');
     }
@@ -37,7 +37,7 @@ abstract class AbstractMessage extends AbstractPart
      *
      * @return EmailAddress[] Empty array in case message has no To: recipients
      */
-    public function getTo(): array
+    final public function getTo(): array
     {
         return $this->getHeaders()->get('to') ?: [];
     }
@@ -47,7 +47,7 @@ abstract class AbstractMessage extends AbstractPart
      *
      * @return EmailAddress[] Empty array in case message has no CC: recipients
      */
-    public function getCc(): array
+    final public function getCc(): array
     {
         return $this->getHeaders()->get('cc') ?: [];
     }
@@ -57,7 +57,7 @@ abstract class AbstractMessage extends AbstractPart
      *
      * @return EmailAddress[] Empty array in case message has no BCC: recipients
      */
-    public function getBcc(): array
+    final public function getBcc(): array
     {
         return $this->getHeaders()->get('bcc') ?: [];
     }
@@ -67,7 +67,7 @@ abstract class AbstractMessage extends AbstractPart
      *
      * @return EmailAddress[] Empty array in case message has no Reply-To: recipients
      */
-    public function getReplyTo(): array
+    final public function getReplyTo(): array
     {
         return $this->getHeaders()->get('reply_to') ?: [];
     }
@@ -77,7 +77,7 @@ abstract class AbstractMessage extends AbstractPart
      *
      * @return EmailAddress[] Empty array in case message has no Sender: recipients
      */
-    public function getSender(): array
+    final public function getSender(): array
     {
         return $this->getHeaders()->get('sender') ?: [];
     }
@@ -87,7 +87,7 @@ abstract class AbstractMessage extends AbstractPart
      *
      * @return EmailAddress[] Empty array in case message has no Return-Path: recipients
      */
-    public function getReturnPath(): array
+    final public function getReturnPath(): array
     {
         return $this->getHeaders()->get('return_path') ?: [];
     }
@@ -97,7 +97,7 @@ abstract class AbstractMessage extends AbstractPart
      *
      * @return \DateTimeImmutable
      */
-    public function getDate(): \DateTimeImmutable
+    final public function getDate(): \DateTimeImmutable
     {
         return $this->getHeaders()->get('date');
     }
@@ -107,7 +107,7 @@ abstract class AbstractMessage extends AbstractPart
      *
      * @return int
      */
-    public function getSize()
+    final public function getSize()
     {
         return $this->getHeaders()->get('size');
     }
@@ -117,7 +117,7 @@ abstract class AbstractMessage extends AbstractPart
      *
      * @return string
      */
-    public function getSubject()
+    final public function getSubject()
     {
         return $this->getHeaders()->get('subject');
     }
@@ -127,7 +127,7 @@ abstract class AbstractMessage extends AbstractPart
      *
      * @return string | null Null if message has no HTML message part
      */
-    public function getBodyHtml()
+    final public function getBodyHtml()
     {
         $iterator = new \RecursiveIteratorIterator($this, \RecursiveIteratorIterator::SELF_FIRST);
         foreach ($iterator as $part) {
@@ -149,7 +149,7 @@ abstract class AbstractMessage extends AbstractPart
      *
      * @return string
      */
-    public function getBodyText()
+    final public function getBodyText()
     {
         $iterator = new \RecursiveIteratorIterator($this, \RecursiveIteratorIterator::SELF_FIRST);
         foreach ($iterator as $part) {
@@ -171,7 +171,7 @@ abstract class AbstractMessage extends AbstractPart
      *
      * @return AttachmentInterface[]
      */
-    public function getAttachments(): array
+    final public function getAttachments(): array
     {
         if (null === $this->attachments) {
             $this->attachments = [];
@@ -197,7 +197,7 @@ abstract class AbstractMessage extends AbstractPart
      *
      * @return bool
      */
-    public function hasAttachments(): bool
+    final public function hasAttachments(): bool
     {
         return \count($this->getAttachments()) > 0;
     }

--- a/src/Message/AbstractPart.php
+++ b/src/Message/AbstractPart.php
@@ -6,33 +6,12 @@ namespace Ddeboer\Imap\Message;
 
 use Ddeboer\Imap\Exception\UnexpectedEncodingException;
 use Ddeboer\Imap\ImapResourceInterface;
-use Ddeboer\Imap\Parameters;
 
 /**
  * A message part.
  */
-class Part implements \RecursiveIterator
+abstract class AbstractPart implements PartInterface
 {
-    const TYPE_TEXT = 'text';
-    const TYPE_MULTIPART = 'multipart';
-    const TYPE_MESSAGE = 'message';
-    const TYPE_APPLICATION = 'application';
-    const TYPE_AUDIO = 'audio';
-    const TYPE_IMAGE = 'image';
-    const TYPE_VIDEO = 'video';
-    const TYPE_MODEL = 'model';
-    const TYPE_OTHER = 'other';
-    const TYPE_UNKNOWN = 'unknown';
-
-    const ENCODING_7BIT = '7bit';
-    const ENCODING_8BIT = '8bit';
-    const ENCODING_BINARY = 'binary';
-    const ENCODING_BASE64 = 'base64';
-    const ENCODING_QUOTED_PRINTABLE = 'quoted-printable';
-
-    const SUBTYPE_PLAIN = 'PLAIN';
-    const SUBTYPE_HTML = 'HTML';
-
     private $typesMap = [
         \TYPETEXT => self::TYPE_TEXT,
         \TYPEMULTIPART => self::TYPE_MULTIPART,
@@ -240,7 +219,7 @@ class Part implements \RecursiveIterator
 
                 $newPartClass = $this->isAttachment($partStructure)
                     ? Attachment::class
-                    : self::class
+                    : SimplePart::class
                 ;
 
                 $this->parts[] = new $newPartClass($this->resource, $this->messageNumber, $partNumber, $partStructure);
@@ -251,7 +230,7 @@ class Part implements \RecursiveIterator
     /**
      * Get an array of all parts for this message.
      *
-     * @return self[]
+     * @return PartInterface[]
      */
     public function getParts(): array
     {

--- a/src/Message/AbstractPart.php
+++ b/src/Message/AbstractPart.php
@@ -94,42 +94,42 @@ abstract class AbstractPart implements PartInterface
      *
      * @return int
      */
-    public function getNumber(): int
+    final public function getNumber(): int
     {
         return $this->messageNumber;
     }
 
-    public function getCharset(): string
+    final public function getCharset(): string
     {
         return $this->parameters->get('charset');
     }
 
-    public function getType()
+    final public function getType()
     {
         return $this->type;
     }
 
-    public function getSubtype()
+    final public function getSubtype()
     {
         return $this->subtype;
     }
 
-    public function getEncoding()
+    final public function getEncoding()
     {
         return $this->encoding;
     }
 
-    public function getBytes()
+    final public function getBytes()
     {
         return $this->bytes;
     }
 
-    public function getLines()
+    final public function getLines()
     {
         return $this->lines;
     }
 
-    public function getParameters(): Parameters
+    final public function getParameters(): Parameters
     {
         return $this->parameters;
     }
@@ -153,7 +153,7 @@ abstract class AbstractPart implements PartInterface
      *
      * @return string
      */
-    public function getDecodedContent(): string
+    final public function getDecodedContent(): string
     {
         if (null === $this->decodedContent) {
             $content = $this->getContent();
@@ -175,7 +175,7 @@ abstract class AbstractPart implements PartInterface
         return $this->decodedContent;
     }
 
-    public function getStructure(): \stdClass
+    final public function getStructure(): \stdClass
     {
         return $this->structure;
     }
@@ -232,47 +232,47 @@ abstract class AbstractPart implements PartInterface
      *
      * @return PartInterface[]
      */
-    public function getParts(): array
+    final public function getParts(): array
     {
         return $this->parts;
     }
 
-    public function current()
+    final public function current()
     {
         return $this->parts[$this->key];
     }
 
-    public function getChildren()
+    final public function getChildren()
     {
         return $this->current();
     }
 
-    public function hasChildren()
+    final public function hasChildren()
     {
         return \count($this->parts) > 0;
     }
 
-    public function key()
+    final public function key()
     {
         return $this->key;
     }
 
-    public function next()
+    final public function next()
     {
         ++$this->key;
     }
 
-    public function rewind()
+    final public function rewind()
     {
         $this->key = 0;
     }
 
-    public function valid()
+    final public function valid()
     {
         return isset($this->parts[$this->key]);
     }
 
-    public function getDisposition()
+    final public function getDisposition()
     {
         return $this->disposition;
     }

--- a/src/Message/Attachment.php
+++ b/src/Message/Attachment.php
@@ -9,7 +9,7 @@ use Ddeboer\Imap\Exception\NotEmbeddedMessageException;
 /**
  * An e-mail attachment.
  */
-final class Attachment extends Part
+final class Attachment extends AbstractPart implements AttachmentInterface
 {
     /**
      * Get attachment filename.
@@ -32,7 +32,7 @@ final class Attachment extends Part
         return $this->parameters->get('size');
     }
 
-    public function isEmbeddedMessage()
+    public function isEmbeddedMessage(): bool
     {
         return self::TYPE_MESSAGE === $this->type;
     }
@@ -42,9 +42,9 @@ final class Attachment extends Part
      *
      * @throws NotEmbeddedMessageException
      *
-     * @return EmbeddedMessage
+     * @return EmbeddedMessageInterface
      */
-    public function getEmbeddedMessage(): EmbeddedMessage
+    public function getEmbeddedMessage(): EmbeddedMessageInterface
     {
         if (!$this->isEmbeddedMessage()) {
             throw new NotEmbeddedMessageException(\sprintf(

--- a/src/Message/AttachmentInterface.php
+++ b/src/Message/AttachmentInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ddeboer\Imap\Message;
+
+/**
+ * An e-mail attachment.
+ */
+interface AttachmentInterface extends PartInterface
+{
+    /**
+     * Get attachment filename.
+     *
+     * @return string
+     */
+    public function getFilename(): string;
+
+    /**
+     * Get attachment file size.
+     *
+     * @return int Number of bytes
+     */
+    public function getSize();
+
+    public function isEmbeddedMessage(): bool;
+
+    /**
+     * Return embedded message.
+     *
+     * @return EmbeddedMessageInterface
+     */
+    public function getEmbeddedMessage(): EmbeddedMessageInterface;
+}

--- a/src/Message/BasicMessageInterface.php
+++ b/src/Message/BasicMessageInterface.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ddeboer\Imap\Message;
+
+interface BasicMessageInterface extends PartInterface
+{
+    /**
+     * Get raw message headers.
+     *
+     * @return string
+     */
+    public function getRawHeaders(): string;
+
+    /**
+     * Get the raw message, including all headers, parts, etc. unencoded and unparsed.
+     *
+     * @return string the raw message
+     */
+    public function getRawMessage(): string;
+
+    /**
+     * Get message headers.
+     *
+     * @return Headers
+     */
+    public function getHeaders(): Headers;
+
+    /**
+     * Get message id.
+     *
+     * A unique message id in the form <...>
+     *
+     * @return string
+     */
+    public function getId(): string;
+
+    /**
+     * Get message sender (from headers).
+     *
+     * @return EmailAddress
+     */
+    public function getFrom(): EmailAddress;
+
+    /**
+     * Get To recipients.
+     *
+     * @return EmailAddress[] Empty array in case message has no To: recipients
+     */
+    public function getTo(): array;
+
+    /**
+     * Get Cc recipients.
+     *
+     * @return EmailAddress[] Empty array in case message has no CC: recipients
+     */
+    public function getCc(): array;
+
+    /**
+     * Get Bcc recipients.
+     *
+     * @return EmailAddress[] Empty array in case message has no BCC: recipients
+     */
+    public function getBcc(): array;
+
+    /**
+     * Get Reply-To recipients.
+     *
+     * @return EmailAddress[] Empty array in case message has no Reply-To: recipients
+     */
+    public function getReplyTo(): array;
+
+    /**
+     * Get Sender.
+     *
+     * @return EmailAddress[] Empty array in case message has no Sender: recipients
+     */
+    public function getSender(): array;
+
+    /**
+     * Get Return-Path.
+     *
+     * @return EmailAddress[] Empty array in case message has no Return-Path: recipients
+     */
+    public function getReturnPath(): array;
+
+    /**
+     * Get date (from headers).
+     *
+     * @return \DateTimeImmutable
+     */
+    public function getDate(): \DateTimeImmutable;
+
+    /**
+     * Get message size (from headers).
+     *
+     * @return int
+     */
+    public function getSize();
+
+    /**
+     * Get message subject (from headers).
+     *
+     * @return string
+     */
+    public function getSubject();
+
+    /**
+     * Get body HTML.
+     *
+     * @return string | null Null if message has no HTML message part
+     */
+    public function getBodyHtml();
+
+    /**
+     * Get body text.
+     *
+     * @return string
+     */
+    public function getBodyText();
+
+    /**
+     * Get attachments (if any) linked to this e-mail.
+     *
+     * @return AttachmentInterface[]
+     */
+    public function getAttachments(): array;
+
+    /**
+     * Does this message have attachments?
+     *
+     * @return bool
+     */
+    public function hasAttachments(): bool;
+}

--- a/src/Message/EmbeddedMessage.php
+++ b/src/Message/EmbeddedMessage.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Ddeboer\Imap\Message;
 
-final class EmbeddedMessage extends AbstractMessage
+final class EmbeddedMessage extends AbstractMessage implements EmbeddedMessageInterface
 {
     private $headers;
     private $rawHeaders;

--- a/src/Message/EmbeddedMessageInterface.php
+++ b/src/Message/EmbeddedMessageInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ddeboer\Imap\Message;
+
+interface EmbeddedMessageInterface extends BasicMessageInterface
+{
+}

--- a/src/Message/Headers.php
+++ b/src/Message/Headers.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Ddeboer\Imap\Message;
 
 use Ddeboer\Imap\Exception\InvalidDateHeaderException;
-use Ddeboer\Imap\Parameters;
 
 /**
  * Collection of message headers.

--- a/src/Message/Parameters.php
+++ b/src/Message/Parameters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Ddeboer\Imap;
+namespace Ddeboer\Imap\Message;
 
 class Parameters extends \ArrayIterator
 {
@@ -32,7 +32,7 @@ class Parameters extends \ArrayIterator
         foreach ($parts as $part) {
             $text = $part->text;
             if ('default' !== $part->charset) {
-                $text = Message\Transcoder::decode($text, $part->charset);
+                $text = Transcoder::decode($text, $part->charset);
             }
 
             $decoded .= $text;

--- a/src/Message/PartInterface.php
+++ b/src/Message/PartInterface.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ddeboer\Imap\Message;
+
+/**
+ * A message part.
+ */
+interface PartInterface extends \RecursiveIterator
+{
+    const TYPE_TEXT = 'text';
+    const TYPE_MULTIPART = 'multipart';
+    const TYPE_MESSAGE = 'message';
+    const TYPE_APPLICATION = 'application';
+    const TYPE_AUDIO = 'audio';
+    const TYPE_IMAGE = 'image';
+    const TYPE_VIDEO = 'video';
+    const TYPE_MODEL = 'model';
+    const TYPE_OTHER = 'other';
+    const TYPE_UNKNOWN = 'unknown';
+
+    const ENCODING_7BIT = '7bit';
+    const ENCODING_8BIT = '8bit';
+    const ENCODING_BINARY = 'binary';
+    const ENCODING_BASE64 = 'base64';
+    const ENCODING_QUOTED_PRINTABLE = 'quoted-printable';
+
+    const SUBTYPE_PLAIN = 'PLAIN';
+    const SUBTYPE_HTML = 'HTML';
+
+    /**
+     * Get message number (from headers).
+     *
+     * @return int
+     */
+    public function getNumber(): int;
+
+    public function getCharset(): string;
+
+    public function getType();
+
+    public function getSubtype();
+
+    public function getEncoding();
+
+    public function getDisposition();
+
+    public function getBytes();
+
+    public function getLines();
+
+    public function getParameters(): Parameters;
+
+    /**
+     * Get raw part content.
+     *
+     * @return string
+     */
+    public function getContent(): string;
+
+    /**
+     * Get decoded part content.
+     *
+     * @return string
+     */
+    public function getDecodedContent(): string;
+
+    public function getStructure(): \stdClass;
+
+    /**
+     * Get an array of all parts for this message.
+     *
+     * @return PartInterface[]
+     */
+    public function getParts(): array;
+}

--- a/src/Message/SimplePart.php
+++ b/src/Message/SimplePart.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ddeboer\Imap\Message;
+
+/**
+ * A message part.
+ */
+final class SimplePart extends AbstractPart
+{
+}

--- a/src/MessageInterface.php
+++ b/src/MessageInterface.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ddeboer\Imap;
+
+/**
+ * An IMAP message (e-mail).
+ */
+interface MessageInterface extends Message\BasicMessageInterface
+{
+    /**
+     * Get raw part content.
+     *
+     * @return string
+     */
+    public function getContent(): string;
+
+    /**
+     * Get message recent flag value (from headers).
+     *
+     * @return string
+     */
+    public function isRecent(): string;
+
+    /**
+     * Get message unseen flag value (from headers).
+     *
+     * @return bool
+     */
+    public function isUnseen(): bool;
+
+    /**
+     * Get message flagged flag value (from headers).
+     *
+     * @return bool
+     */
+    public function isFlagged(): bool;
+
+    /**
+     * Get message answered flag value (from headers).
+     *
+     * @return bool
+     */
+    public function isAnswered(): bool;
+
+    /**
+     * Get message deleted flag value (from headers).
+     *
+     * @return bool
+     */
+    public function isDeleted(): bool;
+
+    /**
+     * Get message draft flag value (from headers).
+     *
+     * @return bool
+     */
+    public function isDraft(): bool;
+
+    /**
+     * Has the message been marked as read?
+     *
+     * @return bool
+     */
+    public function isSeen(): bool;
+
+    /**
+     * Mark message as seen.
+     *
+     * @return bool
+     */
+    public function maskAsSeen(): bool;
+
+    /**
+     * Move message to another mailbox.
+     *
+     * @param Mailbox $mailbox
+     */
+    public function copy(MailboxInterface $mailbox);
+
+    /**
+     * Move message to another mailbox.
+     *
+     * @param Mailbox $mailbox
+     */
+    public function move(MailboxInterface $mailbox);
+
+    /**
+     * Delete message.
+     */
+    public function delete();
+
+    /**
+     * Set Flag Message.
+     *
+     * @param $flag \Seen, \Answered, \Flagged, \Deleted, and \Draft
+     *
+     * @return bool
+     */
+    public function setFlag(string $flag): bool;
+
+    /**
+     * Clear Flag Message.
+     *
+     * @param $flag \Seen, \Answered, \Flagged, \Deleted, and \Draft
+     *
+     * @return bool
+     */
+    public function clearFlag(string $flag): bool;
+}

--- a/src/MessageIterator.php
+++ b/src/MessageIterator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Ddeboer\Imap;
 
-final class MessageIterator extends \ArrayIterator
+final class MessageIterator extends \ArrayIterator implements MessageIteratorInterface
 {
     private $resource;
 
@@ -24,9 +24,9 @@ final class MessageIterator extends \ArrayIterator
     /**
      * Get current message.
      *
-     * @return Message
+     * @return MessageInterface
      */
-    public function current(): Message
+    public function current(): MessageInterface
     {
         return new Message($this->resource, parent::current());
     }

--- a/src/MessageIteratorInterface.php
+++ b/src/MessageIteratorInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ddeboer\Imap;
+
+interface MessageIteratorInterface extends \Iterator
+{
+    /**
+     * Get current message.
+     *
+     * @return MessageInterface
+     */
+    public function current(): MessageInterface;
+}

--- a/src/Server.php
+++ b/src/Server.php
@@ -9,7 +9,7 @@ use Ddeboer\Imap\Exception\AuthenticationFailedException;
 /**
  * An IMAP server.
  */
-final class Server
+final class Server implements ServerInterface
 {
     /**
      * @var string Internet domain name or bracketed IP address of server
@@ -64,9 +64,9 @@ final class Server
      *
      * @throws AuthenticationFailedException
      *
-     * @return Connection
+     * @return ConnectionInterface
      */
-    public function authenticate(string $username, string $password): Connection
+    public function authenticate(string $username, string $password): ConnectionInterface
     {
         // Wrap imap_open, which gives notices instead of exceptions
         \set_error_handler(function ($nr, $message) use ($username) {

--- a/src/ServerInterface.php
+++ b/src/ServerInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ddeboer\Imap;
+
+/**
+ * An IMAP server.
+ */
+interface ServerInterface
+{
+    /**
+     * Authenticate connection.
+     *
+     * @param string $username Username
+     * @param string $password Password
+     *
+     * @return ConnectionInterface
+     */
+    public function authenticate(string $username, string $password): ConnectionInterface;
+}

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -15,7 +15,7 @@ use Ddeboer\Imap\Mailbox;
  * @covers \Ddeboer\Imap\Connection
  * @covers \Ddeboer\Imap\ImapResource
  */
-class ConnectionTest extends AbstractTest
+final class ConnectionTest extends AbstractTest
 {
     public function testValidResourceStream()
     {

--- a/tests/EmbeddedMessageTest.php
+++ b/tests/EmbeddedMessageTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Ddeboer\Imap\Tests;
 
 use Ddeboer\Imap\Exception\NotEmbeddedMessageException;
-use Ddeboer\Imap\Message\Part;
+use Ddeboer\Imap\Message\PartInterface;
 
 /**
  * @covers \Ddeboer\Imap\Message\AbstractMessage
@@ -51,8 +51,8 @@ final class EmbeddedMessageTest extends AbstractTest
         $this->assertSame('attachment', $embeddedAttachment->getDisposition());
         $this->assertSame('IHRoaXMgaXMgY29udGVudCBvZiB0ZXN0IGZpbGU=', $embeddedAttachment->getContent());
         $this->assertSame('base64', $embeddedAttachment->getEncoding());
-        $this->assertSame(Part::TYPE_TEXT, $embeddedAttachment->getType());
-        $this->assertSame(Part::SUBTYPE_PLAIN, $embeddedAttachment->getSubtype());
+        $this->assertSame(PartInterface::TYPE_TEXT, $embeddedAttachment->getType());
+        $this->assertSame(PartInterface::SUBTYPE_PLAIN, $embeddedAttachment->getSubtype());
         $this->assertSame(' this is content of test file', $embeddedAttachment->getDecodedContent());
         $this->assertSame('testfile.txt', $embeddedAttachment->getFilename());
 

--- a/tests/MailboxTest.php
+++ b/tests/MailboxTest.php
@@ -12,7 +12,7 @@ use Ddeboer\Imap\Mailbox;
  * @covers \Ddeboer\Imap\Exception\AbstractException
  * @covers \Ddeboer\Imap\Mailbox
  */
-class MailboxTest extends AbstractTest
+final class MailboxTest extends AbstractTest
 {
     /**
      * @var Mailbox

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -7,8 +7,8 @@ namespace Ddeboer\Imap\Tests;
 use Ddeboer\Imap\Exception\InvalidDateHeaderException;
 use Ddeboer\Imap\Exception\UnsupportedCharsetException;
 use Ddeboer\Imap\Message\EmailAddress;
+use Ddeboer\Imap\Message\Parameters;
 use Ddeboer\Imap\MessageIterator;
-use Ddeboer\Imap\Parameters;
 use Ddeboer\Imap\Search;
 use Zend\Mime\Mime;
 
@@ -20,9 +20,9 @@ use Zend\Mime\Mime;
  * @covers \Ddeboer\Imap\Message\Attachment
  * @covers \Ddeboer\Imap\Message\EmailAddress
  * @covers \Ddeboer\Imap\Message\Headers
+ * @covers \Ddeboer\Imap\Message\Parameters
  * @covers \Ddeboer\Imap\Message\Part
  * @covers \Ddeboer\Imap\Message\Transcoder
- * @covers \Ddeboer\Imap\Parameters
  */
 class MessageTest extends AbstractTest
 {

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -17,14 +17,15 @@ use Zend\Mime\Mime;
  * @covers \Ddeboer\Imap\Message
  * @covers \Ddeboer\Imap\MessageIterator
  * @covers \Ddeboer\Imap\Message\AbstractMessage
+ * @covers \Ddeboer\Imap\Message\AbstractPart
  * @covers \Ddeboer\Imap\Message\Attachment
  * @covers \Ddeboer\Imap\Message\EmailAddress
  * @covers \Ddeboer\Imap\Message\Headers
  * @covers \Ddeboer\Imap\Message\Parameters
- * @covers \Ddeboer\Imap\Message\Part
+ * @covers \Ddeboer\Imap\Message\SimplePart
  * @covers \Ddeboer\Imap\Message\Transcoder
  */
-class MessageTest extends AbstractTest
+final class MessageTest extends AbstractTest
 {
     /**
      * @var \Ddeboer\Imap\Mailbox

--- a/tests/Search/Date/AbstractDateTest.php
+++ b/tests/Search/Date/AbstractDateTest.php
@@ -10,7 +10,7 @@ use Ddeboer\Imap\Tests\AbstractTest;
 /**
  * @covers \Ddeboer\Imap\Search\AbstractDate
  */
-class AbstractDateTest extends AbstractTest
+final class AbstractDateTest extends AbstractTest
 {
     protected function setUp()
     {

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -10,7 +10,7 @@ use Ddeboer\Imap\Server;
 /**
  * @covers \Ddeboer\Imap\Server
  */
-class ServerTest extends AbstractTest
+final class ServerTest extends AbstractTest
 {
     public function testValidConnection()
     {


### PR DESCRIPTION
### BC breaks

1. Parts now extend `Ddeboer\Imap\Message\AbstractPart`
1. Part that aren't embedded messages nor attachments are now `Ddeboer\Imap\Message\SimplePart`
1. `Ddeboer\Imap{ => \Message}\Parameters`

This helps typehinting segregation, and now all non-abstract classes are final