### PR TITLE
If charset is not specified defaults to "us-ascii"

### DIFF
--- a/src/Message/AbstractPart.php
+++ b/src/Message/AbstractPart.php
@@ -172,7 +172,7 @@ abstract class AbstractPart implements PartInterface
      */
     final public function getCharset(): string
     {
-        return $this->parameters->get('charset');
+        return $this->parameters->get('charset') ?: 'us-ascii';
     }
 
     /**

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -575,4 +575,23 @@ final class MessageTest extends AbstractTest
             $this->assertContains($expectedContains, \rtrim($attachment->getContent()), $attachment->getFilename());
         }
     }
+
+    public function testSimpleMessageWithoutCharset()
+    {
+        $this->mailbox->addMessage($this->getFixture('without_charset_plain_only'));
+
+        $message = $this->mailbox->getMessage(1);
+
+        $this->assertSame('Hi', \rtrim($message->getBodyText()));
+    }
+
+    public function testMultipartMessageWithoutCharset()
+    {
+        $this->mailbox->addMessage($this->getFixture('without_charset_simple_multipart'));
+
+        $message = $this->mailbox->getMessage(1);
+
+        $this->assertSame('MyPlain', \rtrim($message->getBodyText()));
+        $this->assertSame('MyHtml', \rtrim($message->getBodyHtml()));
+    }
 }

--- a/tests/fixtures/without_charset_plain_only.eml
+++ b/tests/fixtures/without_charset_plain_only.eml
@@ -1,0 +1,8 @@
+From: from@there.com
+To: to@here.com
+Subject: Nuu
+Date: Wed, 13 Sep 2017 13:05:45 +0200
+Content-Type: text/plain; charset=
+Content-Transfer-Encoding: quoted-printable
+
+Hi

--- a/tests/fixtures/without_charset_simple_multipart.eml
+++ b/tests/fixtures/without_charset_simple_multipart.eml
@@ -1,0 +1,24 @@
+From: from@there.com
+To: to@here.com
+Date: Wed, 27 Sep 2017 12:48:51 +0200
+Subject: test
+Content-Type: multipart/alternative;
+	boundary="----=_NextPart_000_0081_01D32C91.033E7020"
+
+This is a multipart message in MIME format.
+
+------=_NextPart_000_0081_01D32C91.033E7020
+Content-Type: text/plain;
+	charset=
+Content-Transfer-Encoding: 7bit
+
+MyPlain
+
+------=_NextPart_000_0081_01D32C91.033E7020
+Content-Type: text/html;
+	charset=""
+Content-Transfer-Encoding: quoted-printable
+
+MyHtml
+------=_NextPart_000_0081_01D32C91.033E7020--
+


### PR DESCRIPTION
Related to https://github.com/ddeboer/imap/issues/226.

#### WARNING

Even if the fix could resolve the bug, with Dovecot we can't reproduce `imap_fetchstructure` to return a null charset, but only an empty one.