### PR TITLE
Attachment::getFilename() may be null on inline-att, widen return type

### DIFF
--- a/src/Message/Attachment.php
+++ b/src/Message/Attachment.php
@@ -14,9 +14,9 @@ final class Attachment extends AbstractPart implements AttachmentInterface
     /**
      * Get attachment filename.
      *
-     * @return string
+     * @return null|string
      */
-    public function getFilename(): string
+    public function getFilename()
     {
         return $this->getParameters()->get('filename')
             ?: $this->getParameters()->get('name');

--- a/src/Message/AttachmentInterface.php
+++ b/src/Message/AttachmentInterface.php
@@ -12,9 +12,9 @@ interface AttachmentInterface extends PartInterface
     /**
      * Get attachment filename.
      *
-     * @return string
+     * @return null|string
      */
-    public function getFilename(): string;
+    public function getFilename();
 
     /**
      * Get attachment file size.

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -592,6 +592,16 @@ final class MessageTest extends AbstractTest
         $this->assertSame('MyHtml', \rtrim($message->getBodyHtml()));
     }
 
+    public function testInlineAttachment()
+    {
+        $this->mailbox->addMessage($this->getFixture('inline_attachment'));
+        $message = $this->mailbox->getMessage(1);
+
+        $inline = $message->getAttachments()[0];
+
+        $this->assertNull($inline->getFilename());
+    }
+
     public function testAttachmentMustNotBeCharsetDecoded()
     {
         $parts = [];

--- a/tests/fixtures/inline_attachment.eml
+++ b/tests/fixtures/inline_attachment.eml
@@ -1,0 +1,41 @@
+Content-Type: multipart/mixed;
+	boundary="----=_Part_1114403_1160068121.1505882828080"
+
+------=_Part_1114403_1160068121.1505882828080
+Content-Type: multipart/related;
+	boundary="----=_Part_1114404_576719783.1505882828080"
+
+------=_Part_1114404_576719783.1505882828080
+Content-Type: text/html;charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+<img style=3D"height: auto;" src=3D"cid:ii_15f0aad691bb745f" border=3D"0"/>
+------=_Part_1114404_576719783.1505882828080
+Content-Type: image/png
+Content-Disposition: inline
+Content-Transfer-Encoding: base64
+Content-ID: <ii_15f0aad691bb745f>
+
+iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAMAAADXqc3KAAAB+FBMVEUAAAA/mUPidDHiLi5Cn0Xk
+NTPmeUrkdUg/m0Q0pEfcpSbwaVdKskg+lUP4zA/iLi3msSHkOjVAmETdJSjtYFE/lkPnRj3sWUs8
+kkLeqCVIq0fxvhXqUkbVmSjwa1n1yBLepyX1xxP0xRXqUkboST9KukpHpUbuvRrzrhF/ljbwalju
+ZFM4jELaoSdLtElJrUj1xxP6zwzfqSU4i0HYnydMtUlIqUfywxb60AxZqEXaoifgMCXptR9MtklH
+pEY2iUHWnSjvvRr70QujkC+pUC/90glMuEnlOjVMt0j70QriLS1LtEnnRj3qUUXfIidOjsxAhcZF
+o0bjNDH0xxNLr0dIrUdmntVTkMoyfL8jcLBRuErhJyrgKyb4zA/5zg3tYFBBmUTmQTnhMinruBzv
+vhnxwxZ/st+Ktt5zp9hqota2vtK6y9FemNBblc9HiMiTtMbFtsM6gcPV2r6dwroseLrMrbQrdLGd
+yKoobKbo3Zh+ynrgVllZulTsXE3rV0pIqUf42UVUo0JyjEHoS0HmsiHRGR/lmRz/1hjqnxjvpRWf
+wtOhusaz0LRGf7FEfbDVmqHXlJeW0pbXq5bec3fX0nTnzmuJuWvhoFFhm0FtrziBsjaAaDCYWC+u
+Si6jQS3FsSfLJiTirCOkuCG1KiG+wSC+GBvgyhTszQ64Z77KAAAARXRSTlMAIQRDLyUgCwsE6ebm
+5ubg2dLR0byXl4FDQzU1NDEuLSUgC+vr6urq6ubb29vb2tra2tG8vLu7u7uXl5eXgYGBgYGBLiUA
+LabIAAABsElEQVQoz12S9VPjQBxHt8VaOA6HE+AOzv1wd7pJk5I2adpCC7RUcHd3d3fXf5PvLkxh
+eD++z+yb7GSRlwD/+Hj/APQCZWxM5M+goF+RMbHK594v+tPoiN1uHxkt+xzt9+R9wnRTZZQpXQ0T
+5uP1IQxToyOAZiQu5HEpjeA4SWIoksRxNiGC1tRZJ4LNxgHgnU5nJZBDvuDdl8lzQRBsQ+s9PZt7
+s7Pz8wsL39/DkIfZ4xlB2Gqsq62ta9oxVlVrNZpihFRpGO9fzQw1ms0NDWZz07iGkJmIFH8xxkc3
+a/WWlubmFkv9AB2SEpDvKxbjidN2faseaNV3zoHXvv7wMODJdkOHAegweAfFPx4G67KluxzottCU
+9n8CUqXzcIQdXOytAHqXxomvykhEKN9EFutG22p//0rbNvHVxiJywa8yS2KDfV1dfbu31H8jF1RH
+iTKtWYeHxUvq3bn0pyjCRaiRU6aDO+gb3aEfEeVNsDgm8zzLy9egPa7Qt8TSJdwhjplk06HH43ZN
+J3s91KKCHQ5x4sw1fRGYDZ0n1L4FKb9/BP5JLYxToheoFCVxz57PPS8UhhEpLBVeAAAAAElFTkSu
+QmCC
+------=_Part_1114404_576719783.1505882828080--
+
+------=_Part_1114403_1160068121.1505882828080--


### PR DESCRIPTION
Inline attachments may not have both `'filename'` and  `'name'` parameters. 
In this case `getFilename()` returns `\TypeError`.