### PR TITLE
Use set_error_handler with late exception

### DIFF
--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ddeboer\Imap\Tests;
 
 use Ddeboer\Imap\Exception\InvalidDateHeaderException;
+use Ddeboer\Imap\Exception\MessageDoesNotExistException;
 use Ddeboer\Imap\Exception\UnsupportedCharsetException;
 use Ddeboer\Imap\Message;
 use Ddeboer\Imap\Message\EmailAddress;
@@ -55,6 +56,17 @@ final class MessageTest extends AbstractTest
     protected function setUp()
     {
         $this->mailbox = $this->createMailbox();
+    }
+
+    public function testCustomNonExistentMessageFetch()
+    {
+        $connection = $this->getConnection();
+        $messageNumber = 98765;
+
+        $this->expectException(MessageDoesNotExistException::class);
+        $this->expectExceptionMessageRegExp(\sprintf('/E_WARNING.+%s/s', \preg_quote((string) $messageNumber)));
+
+        new Message($connection->getResource(), $messageNumber);
     }
 
     public function testAlwaysKeepUnseen()


### PR DESCRIPTION
The [@ error control operator](https://secure.php.net/manual/en/language.operators.errorcontrol.php) still triggers the user error handler, if set, so can't be used.

Still, throwing the exception inside the [set_error_handler](https://secure.php.net/manual/en/function.set-error-handler.php) is a mistake because the consecutive [restore_error_handler](https://secure.php.net/manual/en/function.restore-error-handler.php) is never called.

The solution is to:

1. Set an error handler that only writes down the error message
1. Restore the error handler
1. Only then throw the Exception