### PR TITLE
Lazy load structured Headers

### DIFF
--- a/src/Message/Headers.php
+++ b/src/Message/Headers.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Ddeboer\Imap\Message;
 
-use Ddeboer\Imap\Exception\InvalidDateHeaderException;
-
 /**
  * Collection of message headers.
  */
@@ -51,58 +49,26 @@ final class Headers extends Parameters
         switch ($key) {
             case 'msgno':
                 return (int) $value;
-            case 'date':
-                $value = $this->decode($value);
-                $alteredValue = \str_replace(',', '', $value);
-                $alteredValue = \preg_replace('/ +\(.*\)/', '', $alteredValue);
-                if (0 === \preg_match('/\d\d:\d\d:\d\d.* [\+\-]?\d\d:?\d\d/', $alteredValue)) {
-                    $alteredValue .= ' +0000';
-                }
-
-                try {
-                    $date = new \DateTimeImmutable($alteredValue);
-                } catch (\Throwable $ex) {
-                    throw new InvalidDateHeaderException(\sprintf('Invalid Date header found: "%s"', $value), 0, $ex);
-                }
-
-                return $date;
             case 'from':
-                return $this->decodeEmailAddress(\current($value));
             case 'to':
             case 'cc':
             case 'bcc':
             case 'reply_to':
             case 'sender':
             case 'return_path':
-                $emails = [];
                 foreach ($value as $address) {
                     if (isset($address->mailbox)) {
-                        $emails[] = $this->decodeEmailAddress($address);
+                        $address->host = $address->host ?? null;
+                        $address->personal = isset($address->personal) ? $this->decode($address->personal) : null;
                     }
                 }
 
-                return $emails;
+                return $value;
+            case 'date':
             case 'subject':
                 return $this->decode($value);
-            case 'in_reply_to':
-            case 'references':
-                return \explode(' ', $value);
         }
 
         return $value;
-    }
-
-    /**
-     * @param \stdClass $value
-     *
-     * @return EmailAddress
-     */
-    private function decodeEmailAddress(\stdClass $value): EmailAddress
-    {
-        return new EmailAddress(
-            $value->mailbox,
-            isset($value->host) ? $value->host : null,
-            isset($value->personal) ? $this->decode($value->personal) : null
-        );
     }
 }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -493,6 +493,9 @@ final class MessageTest extends AbstractTest
         $this->assertArrayHasKey('date', $headers);
         $this->assertArrayHasKey('recent', $headers);
 
+        $this->assertSame('Wed, 27 Sep 2017 12:48:51 +0200', $headers['date']);
+        $this->assertSame('A_€@{è_Z', $headers['bcc'][0]->personal);
+
         $this->assertFalse($message->isSeen());
     }
 

--- a/tests/fixtures/bcc.eml
+++ b/tests/fixtures/bcc.eml
@@ -5,7 +5,7 @@ Content-Type: text/plain
 Date: Wed, 27 Sep 2017 12:48:51 +0200
 From: from@there.com
 To: to@here.com
-Bcc: bcc@here.com
+Bcc: =?UTF-8?B?QV/igqxAe8OoX1o=?= <bcc@here.com>
 Reply-To: reply-to@here.com
 Sender: sender@here.com
 


### PR DESCRIPTION
Following @wujku issue https://github.com/ddeboer/imap/issues/246 here I'm proposing a change to `Message\Headers` to resolve it.

Since the very first tag in 2013, header validation and specifically EmailAddresses and Date header validation are done at `Message\Headers` construction, meaning that if any error occurs in any header, no header at all can be queried.

An invalid Date would make this code raising the Exception:
```php
$message = $mailbox->getMessage(1);
// throws InvalidDateHeaderException
var_dump($message->getSubject());
```
While I would expect it to be thrown only when needed:
```php
$message = $mailbox->getMessage(1);
// Ok
var_dump($message->getSubject());
// throws InvalidDateHeaderException
var_dump($message->getDate());
```
This PR leaves the `decode` in the Header construction, so all headers will always be UTF-8, but moves the logic to the `Message\AbstractMessage` API.

### Is this a BC break?

Yes and No.

Yes because this code would behave differently:
```php
// Message\Headers is an ArrayIterator
$headers = $message->getHeaders();
var_dump($headers['to']);
// Before: array of EmailAddress
// After: array of \stdClass
var_dump($headers['date']);
// Before: class DateTimeImmutable
// After: string "Wed, 27 Sep 2017 12:48:51 +0200"
```

No because the previous example is not a public API usage (i.e. interfaces signatures), so it wouldn't be an incompatible API change. In fact the following code would behave the same:
```php
var_dump($message->getTo());
// Before & After: array of EmailAddress
var_dump($message->getDate());
// Before & After: class DateTimeImmutable
```

We could in theory make the change fully backward compatible, but we would need to overwrite a lot of `ArrayIterator` functions: `current`, `getArrayCopy`, `next`, `offsetGet`, `get`, `seek`, `serialize` etc. Too complex, doesn't worth the effort.

Moreover, I like the change to the `Message\Headers` contents because the user would be able to choose to query the raw header through the `Message\Headers` instance, or the parsed header through the `Message` API.

At the time of writing, I'm tagging this to the [1.1](https://github.com/ddeboer/imap/milestone/2) milestone expected to be released on 2017-11-06.
If we decide this to be a complete BC break, I'll move it to the [2.0](https://github.com/ddeboer/imap/milestone/3) milestone, expected to be released on 2018-03-05 (at least 6 months after the previous major release to gather other major suggestions).

@ddeboer @wujku what do you think?