### PR TITLE
BasicMessageInterface::getId() can be null

### DIFF
--- a/src/Message/AbstractMessage.php
+++ b/src/Message/AbstractMessage.php
@@ -16,9 +16,9 @@ abstract class AbstractMessage extends AbstractPart
      *
      * A unique message id in the form <...>
      *
-     * @return string
+     * @return null|string
      */
-    final public function getId(): string
+    final public function getId()
     {
         return $this->getHeaders()->get('message_id');
     }

--- a/src/Message/BasicMessageInterface.php
+++ b/src/Message/BasicMessageInterface.php
@@ -32,9 +32,9 @@ interface BasicMessageInterface extends PartInterface
      *
      * A unique message id in the form <...>
      *
-     * @return string
+     * @return null|string
      */
-    public function getId(): string;
+    public function getId();
 
     /**
      * Get message sender (from headers).

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -725,6 +725,15 @@ final class MessageTest extends AbstractTest
         }
     }
 
+    public function testNoMessageId()
+    {
+        $this->mailbox->addMessage($this->getFixture('plain_only'));
+
+        $message = $this->mailbox->getMessage(1);
+
+        $this->assertNull($message->getId());
+    }
+
     private function resetAttachmentCharset(Message $message)
     {
         // Mimic GMAIL behaviour that correctly doesn't report charset


### PR DESCRIPTION
Reference: #253 