### PR TITLE
Deprecate MessageInterface::maskAsSeen() in favour of MessageInterface::markAsSeen()

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -30,6 +30,7 @@ return PhpCsFixer\Config::create()
         'phpdoc_order' => true,
         'phpdoc_types_order' => true,
         'semicolon_after_instruction' => true,
+        'silenced_deprecation_error' => false,
         'simplified_null_return' => true,
     ])
     ->setFinder(

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Reading the message body keeps the message as unseen.
 If you want to mark the message as seen:
 
 ```php
-$message->maskAsSeen();
+$message->markAsSeen();
 ```
 
 Or you can set, or clear, any [flag](https://secure.php.net/manual/en/function.imap-setflag-full.php):

--- a/src/Message.php
+++ b/src/Message.php
@@ -207,8 +207,22 @@ final class Message extends Message\AbstractMessage implements MessageInterface
      * Mark message as seen.
      *
      * @return bool
+     *
+     * @deprecated since version 1.1, to be removed in 2.0
      */
     public function maskAsSeen(): bool
+    {
+        \trigger_error(\sprintf('%s is deprecated and will be removed in 2.0. Use %s::markAsSeen instead.', __METHOD__, __CLASS__), \E_USER_DEPRECATED);
+
+        return $this->markAsSeen();
+    }
+
+    /**
+     * Mark message as seen.
+     *
+     * @return bool
+     */
+    public function markAsSeen(): bool
     {
         return $this->setFlag('\\Seen');
     }

--- a/src/MessageInterface.php
+++ b/src/MessageInterface.php
@@ -69,8 +69,17 @@ interface MessageInterface extends Message\BasicMessageInterface
      * Mark message as seen.
      *
      * @return bool
+     *
+     * @deprecated since version 1.1, to be removed in 2.0
      */
     public function maskAsSeen(): bool;
+
+    /**
+     * Mark message as seen.
+     *
+     * @return bool
+     */
+    public function markAsSeen(): bool;
 
     /**
      * Move message to another mailbox.

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -12,6 +12,7 @@ use Ddeboer\Imap\Message\EmailAddress;
 use Ddeboer\Imap\Message\Parameters;
 use Ddeboer\Imap\MessageIterator;
 use Ddeboer\Imap\Search;
+use PHPUnit\Framework\Error\Deprecated;
 use Zend\Mail;
 use Zend\Mime;
 
@@ -69,6 +70,16 @@ final class MessageTest extends AbstractTest
         new Message($connection->getResource(), $messageNumber);
     }
 
+    public function testDeprecateMaskAsSeen()
+    {
+        $this->createTestMessage($this->mailbox, 'Message A');
+        $message = $this->mailbox->getMessage(1);
+
+        $this->expectException(Deprecated::class);
+
+        $message->maskAsSeen();
+    }
+
     public function testAlwaysKeepUnseen()
     {
         $this->createTestMessage($this->mailbox, 'Message A');
@@ -79,7 +90,7 @@ final class MessageTest extends AbstractTest
         $message->getBodyText();
         $this->assertFalse($message->isSeen());
 
-        $message->maskAsSeen();
+        $message->markAsSeen();
         $this->assertTrue($message->isSeen());
     }
 


### PR DESCRIPTION
Reference: https://github.com/ddeboer/imap/commit/03dda780077d5321963ea5448512009c45373a78#commitcomment-25316466