### PR TITLE
Manageable UnexpectedEncodingException

### DIFF
--- a/src/Message/AbstractPart.php
+++ b/src/Message/AbstractPart.php
@@ -277,6 +277,10 @@ abstract class AbstractPart implements PartInterface
     final public function getDecodedContent(): string
     {
         if (null === $this->decodedContent) {
+            if (self::ENCODING_UNKNOWN === $this->getEncoding()) {
+                throw new UnexpectedEncodingException('Cannot decode a content with an uknown encoding');
+            }
+
             $content = $this->getContent();
             if (self::ENCODING_BASE64 === $this->getEncoding()) {
                 $content = \base64_decode($content);
@@ -322,11 +326,8 @@ abstract class AbstractPart implements PartInterface
     {
         $this->type = $this->typesMap[$structure->type] ?? self::TYPE_UNKNOWN;
 
-        if (!isset($this->encodingsMap[$structure->encoding])) {
-            throw new UnexpectedEncodingException(\sprintf('Cannot decode "%s"', $structure->encoding));
-        }
-
-        $this->encoding = $this->encodingsMap[$structure->encoding];
+        // In our context, \ENCOTHER is as useful as an uknown encoding
+        $this->encoding = $this->encodingsMap[$structure->encoding] ?? self::ENCODING_UNKNOWN;
         $this->subtype = $structure->subtype;
 
         foreach (['disposition', 'bytes', 'description'] as $optional) {

--- a/src/Message/PartInterface.php
+++ b/src/Message/PartInterface.php
@@ -25,6 +25,7 @@ interface PartInterface extends \RecursiveIterator
     const ENCODING_BINARY = 'binary';
     const ENCODING_BASE64 = 'base64';
     const ENCODING_QUOTED_PRINTABLE = 'quoted-printable';
+    const ENCODING_UNKNOWN = 'unknown';
 
     const SUBTYPE_PLAIN = 'PLAIN';
     const SUBTYPE_HTML = 'HTML';

--- a/tests/fixtures/unknown_encoding.eml
+++ b/tests/fixtures/unknown_encoding.eml
@@ -1,0 +1,24 @@
+From: from@there.com
+To: to@here.com
+Date: Wed, 27 Sep 2017 12:48:51 +0200
+Subject: test
+Content-Type: multipart/alternative;
+	boundary="----=_NextPart_000_0081_01D32C91.033E7020"
+
+This is a multipart message in MIME format.
+
+------=_NextPart_000_0081_01D32C91.033E7020
+Content-Type: text/plain;
+	charset=
+Content-Transfer-Encoding: foobar
+
+MyPlain
+
+------=_NextPart_000_0081_01D32C91.033E7020
+Content-Type: text/html;
+	charset=""
+Content-Transfer-Encoding: quoted-printable
+
+MyHtml
+------=_NextPart_000_0081_01D32C91.033E7020--
+


### PR DESCRIPTION
Reference: https://github.com/ddeboer/imap/issues/278

@wujku as you can see in the test, now the exception is thrown only when calling `getDecodedContent()` on the issued part.