### PR TITLE
Implement bulk-move

### DIFF
--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -6,6 +6,7 @@ namespace Ddeboer\Imap;
 
 use DateTimeInterface;
 use Ddeboer\Imap\Exception\InvalidSearchCriteriaException;
+use Ddeboer\Imap\Exception\MessageCopyException;
 use Ddeboer\Imap\Exception\MessageMoveException;
 use Ddeboer\Imap\Search\ConditionInterface;
 use Ddeboer\Imap\Search\LogicalOperator\All;
@@ -262,12 +263,12 @@ final class Mailbox implements MailboxInterface
      * @param array|MessageIterator|string $numbers Message numbers
      * @param MailboxInterface             $mailbox Destination Mailbox to copy the messages to
      *
-     * @throws \Ddeboer\Imap\Exception\MessageMoveException
+     * @throws \Ddeboer\Imap\Exception\MessageCopyException
      */
     public function copy($numbers, MailboxInterface $mailbox)
     {
         if (!\imap_mail_copy($this->resource->getStream(), $this->prepareMessageIds($numbers), $mailbox->getEncodedName(), \CP_UID)) {
-            throw new MessageMoveException(\sprintf('Messages cannot be copied to "%s"', $mailbox->getName()));
+            throw new MessageCopyException(\sprintf('Messages cannot be copied to "%s"', $mailbox->getName()));
         }
     }
 

--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -6,6 +6,7 @@ namespace Ddeboer\Imap;
 
 use DateTimeInterface;
 use Ddeboer\Imap\Exception\InvalidSearchCriteriaException;
+use Ddeboer\Imap\Exception\MessageMoveException;
 use Ddeboer\Imap\Search\ConditionInterface;
 use Ddeboer\Imap\Search\LogicalOperator\All;
 
@@ -254,9 +255,9 @@ final class Mailbox implements MailboxInterface
      * @param array|MessageIteratorInterface|string $numbers Message numbers
      * @param MailboxInterface                      $mailbox Destination Mailbox to move the messages to
      *
-     * @return bool true on success
+     * @throws \Ddeboer\Imap\Exception\MessageMoveException
      */
-    public function move($numbers, MailboxInterface $mailbox): bool
+    public function move($numbers, MailboxInterface $mailbox)
     {
         if ($numbers instanceof MessageIterator) {
             $numbers = $numbers->getArrayCopy();
@@ -266,6 +267,8 @@ final class Mailbox implements MailboxInterface
             $numbers = \implode(',', $numbers);
         }
 
-        return \imap_mail_move($this->resource->getStream(), (string) $numbers, $mailbox->getEncodedName(), \CP_UID);
+        if (!\imap_mail_move($this->resource->getStream(), (string) $numbers, $mailbox->getEncodedName(), \CP_UID)) {
+            throw new MessageMoveException(\sprintf('Messages cannot be moved to "%s"', $mailbox->getName()));
+        }
     }
 }

--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -119,8 +119,8 @@ final class Mailbox implements MailboxInterface
     /**
      * Bulk Set Flag for Messages.
      *
-     * @param string                                $flag    \Seen, \Answered, \Flagged, \Deleted, and \Draft
-     * @param array|MessageIteratorInterface|string $numbers Message numbers
+     * @param string                       $flag    \Seen, \Answered, \Flagged, \Deleted, and \Draft
+     * @param array|MessageIterator|string $numbers Message numbers
      *
      * @return bool
      */
@@ -132,8 +132,8 @@ final class Mailbox implements MailboxInterface
     /**
      * Bulk Clear Flag for Messages.
      *
-     * @param string                                $flag    \Seen, \Answered, \Flagged, \Deleted, and \Draft
-     * @param array|MessageIteratorInterface|string $numbers Message numbers
+     * @param string                       $flag    \Seen, \Answered, \Flagged, \Deleted, and \Draft
+     * @param array|MessageIterator|string $numbers Message numbers
      *
      * @return bool
      */
@@ -244,8 +244,8 @@ final class Mailbox implements MailboxInterface
     /**
      * Bulk move messages.
      *
-     * @param array|MessageIteratorInterface|string $numbers Message numbers
-     * @param MailboxInterface                      $mailbox Destination Mailbox to move the messages to
+     * @param array|MessageIterator|string $numbers Message numbers
+     * @param MailboxInterface             $mailbox Destination Mailbox to move the messages to
      *
      * @throws \Ddeboer\Imap\Exception\MessageMoveException
      */
@@ -259,8 +259,8 @@ final class Mailbox implements MailboxInterface
     /**
      * Bulk copy messages.
      *
-     * @param array|MessageIteratorInterface|string $numbers Message numbers
-     * @param MailboxInterface                      $mailbox Destination Mailbox to copy the messages to
+     * @param array|MessageIterator|string $numbers Message numbers
+     * @param MailboxInterface             $mailbox Destination Mailbox to copy the messages to
      *
      * @throws \Ddeboer\Imap\Exception\MessageMoveException
      */
@@ -274,7 +274,7 @@ final class Mailbox implements MailboxInterface
     /**
      * Prepare message ids for the use with bulk functions.
      *
-     * @param array|MessageIteratorInterface|string $messageIds Message numbers
+     * @param array|MessageIterator|string $messageIds Message numbers
      *
      * @return string
      */

--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -257,6 +257,21 @@ final class Mailbox implements MailboxInterface
     }
 
     /**
+     * Bulk copy messages.
+     *
+     * @param array|MessageIteratorInterface|string $numbers Message numbers
+     * @param MailboxInterface                      $mailbox Destination Mailbox to copy the messages to
+     *
+     * @throws \Ddeboer\Imap\Exception\MessageMoveException
+     */
+    public function copy($numbers, MailboxInterface $mailbox)
+    {
+        if (!\imap_mail_copy($this->resource->getStream(), $this->prepareMessageIds($numbers), $mailbox->getEncodedName(), \CP_UID)) {
+            throw new MessageMoveException(\sprintf('Messages cannot be copied to "%s"', $mailbox->getName()));
+        }
+    }
+
+    /**
      * Prepare message ids for the use with bulk functions.
      *
      * @param array|MessageIteratorInterface|string $messageIds Message numbers

--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -247,4 +247,25 @@ final class Mailbox implements MailboxInterface
 
         return false !== $tree ? $tree : [];
     }
+
+    /**
+     * Bulk move messages.
+     *
+     * @param array|MessageIteratorInterface|string $numbers Message numbers
+     * @param MailboxInterface                      $mailbox Destination Mailbox to move the messages to
+     *
+     * @return bool true on success
+     */
+    public function move($numbers, MailboxInterface $mailbox): bool
+    {
+        if ($numbers instanceof MessageIterator) {
+            $numbers = $numbers->getArrayCopy();
+        }
+
+        if (\is_array($numbers)) {
+            $numbers = \implode(',', $numbers);
+        }
+
+        return \imap_mail_move($this->resource->getStream(), (string) $numbers, $mailbox->getEncodedName(), \CP_UID);
+    }
 }

--- a/src/MailboxInterface.php
+++ b/src/MailboxInterface.php
@@ -135,7 +135,7 @@ interface MailboxInterface extends \Countable, \IteratorAggregate
      * @param array|MessageIterator|string $numbers Message numbers
      * @param MailboxInterface             $mailbox Destination Mailbox to copy the messages to
      *
-     * @throws \Ddeboer\Imap\Exception\MessageMoveException
+     * @throws \Ddeboer\Imap\Exception\MessageCopyException
      */
     public function copy($numbers, self $mailbox);
 }

--- a/src/MailboxInterface.php
+++ b/src/MailboxInterface.php
@@ -118,4 +118,14 @@ interface MailboxInterface extends \Countable, \IteratorAggregate
      * @return array
      */
     public function getThread(): array;
+
+    /**
+     * Bulk move messages.
+     *
+     * @param array|MessageIteratorInterface|string $numbers Message numbers
+     * @param MailboxInterface                      $mailbox Destination Mailbox to move the messages to
+     *
+     * @return bool true on success
+     */
+    public function move($numbers, self $mailbox): bool;
 }

--- a/src/MailboxInterface.php
+++ b/src/MailboxInterface.php
@@ -59,8 +59,8 @@ interface MailboxInterface extends \Countable, \IteratorAggregate
     /**
      * Bulk Set Flag for Messages.
      *
-     * @param string       $flag    \Seen, \Answered, \Flagged, \Deleted, and \Draft
-     * @param array|string $numbers Message numbers
+     * @param string                                $flag    \Seen, \Answered, \Flagged, \Deleted, and \Draft
+     * @param array|MessageIteratorInterface|string $numbers Message numbers
      *
      * @return bool
      */
@@ -69,8 +69,8 @@ interface MailboxInterface extends \Countable, \IteratorAggregate
     /**
      * Bulk Clear Flag for Messages.
      *
-     * @param string       $flag    \Seen, \Answered, \Flagged, \Deleted, and \Draft
-     * @param array|string $numbers Message numbers
+     * @param string                                $flag    \Seen, \Answered, \Flagged, \Deleted, and \Draft
+     * @param array|MessageIteratorInterface|string $numbers Message numbers
      *
      * @return bool
      */

--- a/src/MailboxInterface.php
+++ b/src/MailboxInterface.php
@@ -125,7 +125,7 @@ interface MailboxInterface extends \Countable, \IteratorAggregate
      * @param array|MessageIteratorInterface|string $numbers Message numbers
      * @param MailboxInterface                      $mailbox Destination Mailbox to move the messages to
      *
-     * @return bool true on success
+     * @throws \Ddeboer\Imap\Exception\MessageMoveException
      */
-    public function move($numbers, self $mailbox): bool;
+    public function move($numbers, self $mailbox);
 }

--- a/src/MailboxInterface.php
+++ b/src/MailboxInterface.php
@@ -128,4 +128,14 @@ interface MailboxInterface extends \Countable, \IteratorAggregate
      * @throws \Ddeboer\Imap\Exception\MessageMoveException
      */
     public function move($numbers, self $mailbox);
+
+    /**
+     * Bulk copy messages.
+     *
+     * @param array|MessageIteratorInterface|string $numbers Message numbers
+     * @param MailboxInterface                      $mailbox Destination Mailbox to copy the messages to
+     *
+     * @throws \Ddeboer\Imap\Exception\MessageMoveException
+     */
+    public function copy($numbers, self $mailbox);
 }

--- a/src/MailboxInterface.php
+++ b/src/MailboxInterface.php
@@ -59,8 +59,8 @@ interface MailboxInterface extends \Countable, \IteratorAggregate
     /**
      * Bulk Set Flag for Messages.
      *
-     * @param string                                $flag    \Seen, \Answered, \Flagged, \Deleted, and \Draft
-     * @param array|MessageIteratorInterface|string $numbers Message numbers
+     * @param string                       $flag    \Seen, \Answered, \Flagged, \Deleted, and \Draft
+     * @param array|MessageIterator|string $numbers Message numbers
      *
      * @return bool
      */
@@ -69,8 +69,8 @@ interface MailboxInterface extends \Countable, \IteratorAggregate
     /**
      * Bulk Clear Flag for Messages.
      *
-     * @param string                                $flag    \Seen, \Answered, \Flagged, \Deleted, and \Draft
-     * @param array|MessageIteratorInterface|string $numbers Message numbers
+     * @param string                       $flag    \Seen, \Answered, \Flagged, \Deleted, and \Draft
+     * @param array|MessageIterator|string $numbers Message numbers
      *
      * @return bool
      */
@@ -122,8 +122,8 @@ interface MailboxInterface extends \Countable, \IteratorAggregate
     /**
      * Bulk move messages.
      *
-     * @param array|MessageIteratorInterface|string $numbers Message numbers
-     * @param MailboxInterface                      $mailbox Destination Mailbox to move the messages to
+     * @param array|MessageIterator|string $numbers Message numbers
+     * @param MailboxInterface             $mailbox Destination Mailbox to move the messages to
      *
      * @throws \Ddeboer\Imap\Exception\MessageMoveException
      */
@@ -132,8 +132,8 @@ interface MailboxInterface extends \Countable, \IteratorAggregate
     /**
      * Bulk copy messages.
      *
-     * @param array|MessageIteratorInterface|string $numbers Message numbers
-     * @param MailboxInterface                      $mailbox Destination Mailbox to copy the messages to
+     * @param array|MessageIterator|string $numbers Message numbers
+     * @param MailboxInterface             $mailbox Destination Mailbox to copy the messages to
      *
      * @throws \Ddeboer\Imap\Exception\MessageMoveException
      */

--- a/tests/MailboxTest.php
+++ b/tests/MailboxTest.php
@@ -10,6 +10,7 @@ use Ddeboer\Imap\Exception\MessageDoesNotExistException;
 use Ddeboer\Imap\Exception\MessageMoveException;
 use Ddeboer\Imap\Exception\ReopenMailboxException;
 use Ddeboer\Imap\MailboxInterface;
+use Ddeboer\Imap\MessageIterator;
 
 /**
  * @covers \Ddeboer\Imap\Exception\AbstractException
@@ -234,6 +235,7 @@ final class MailboxTest extends AbstractTest
         $this->assertSame(0, $this->mailbox->count());
 
         // move back by iterator
+        /** @var MessageIterator $messages */
         $messages = $anotherMailbox->getMessages();
         $anotherMailbox->move($messages, $this->mailbox);
         $this->getConnection()->expunge();

--- a/tests/MailboxTest.php
+++ b/tests/MailboxTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ddeboer\Imap\Tests;
 
 use DateTimeImmutable;
+use Ddeboer\Imap\Exception\MessageCopyException;
 use Ddeboer\Imap\Exception\MessageDoesNotExistException;
 use Ddeboer\Imap\Exception\MessageMoveException;
 use Ddeboer\Imap\Exception\ReopenMailboxException;
@@ -260,7 +261,7 @@ final class MailboxTest extends AbstractTest
 
         // test failing bulk copy - try to move to a non-existent mailbox
         $this->getConnection()->deleteMailbox($anotherMailbox);
-        $this->expectException(MessageMoveException::class);
+        $this->expectException(MessageCopyException::class);
         $this->mailbox->copy($messages, $anotherMailbox);
     }
 }

--- a/tests/MailboxTest.php
+++ b/tests/MailboxTest.php
@@ -6,6 +6,7 @@ namespace Ddeboer\Imap\Tests;
 
 use DateTimeImmutable;
 use Ddeboer\Imap\Exception\MessageDoesNotExistException;
+use Ddeboer\Imap\Exception\MessageMoveException;
 use Ddeboer\Imap\Exception\ReopenMailboxException;
 use Ddeboer\Imap\MailboxInterface;
 
@@ -238,5 +239,10 @@ final class MailboxTest extends AbstractTest
 
         $this->assertSame(0, $anotherMailbox->count());
         $this->assertSame(3, $this->mailbox->count());
+
+        // test failing bulk move - try to move to a non-existent mailbox
+        $this->getConnection()->deleteMailbox($anotherMailbox);
+        $this->expectException(MessageMoveException::class);
+        $this->mailbox->move($messages, $anotherMailbox);
     }
 }

--- a/tests/MailboxTest.php
+++ b/tests/MailboxTest.php
@@ -7,7 +7,7 @@ namespace Ddeboer\Imap\Tests;
 use DateTimeImmutable;
 use Ddeboer\Imap\Exception\MessageDoesNotExistException;
 use Ddeboer\Imap\Exception\ReopenMailboxException;
-use Ddeboer\Imap\Mailbox;
+use Ddeboer\Imap\MailboxInterface;
 
 /**
  * @covers \Ddeboer\Imap\Exception\AbstractException
@@ -16,6 +16,7 @@ use Ddeboer\Imap\Mailbox;
  */
 final class MailboxTest extends AbstractTest
 {
+    /** @var MailboxInterface */
     protected $mailbox;
 
     protected function setUp()
@@ -214,5 +215,28 @@ final class MailboxTest extends AbstractTest
 
         $this->assertTrue($message->isSeen());
         $this->assertSame(' 3-Jan-2012 09:30:03 +0000', $message->getHeaders()->get('maildate'));
+    }
+
+    public function testBulkMove()
+    {
+        $anotherMailbox = $this->createMailbox();
+
+        // Test move by id
+        $messages = [1, 2, 3];
+
+        $this->assertSame(0, $anotherMailbox->count());
+        $this->mailbox->move($messages, $anotherMailbox);
+        $this->getConnection()->expunge();
+
+        $this->assertSame(3, $anotherMailbox->count());
+        $this->assertSame(0, $this->mailbox->count());
+
+        // move back by iterator
+        $messages = $anotherMailbox->getMessages();
+        $anotherMailbox->move($messages, $this->mailbox);
+        $this->getConnection()->expunge();
+
+        $this->assertSame(0, $anotherMailbox->count());
+        $this->assertSame(3, $this->mailbox->count());
     }
 }

--- a/tests/MailboxTest.php
+++ b/tests/MailboxTest.php
@@ -245,4 +245,22 @@ final class MailboxTest extends AbstractTest
         $this->expectException(MessageMoveException::class);
         $this->mailbox->move($messages, $anotherMailbox);
     }
+
+    public function testBulkCopy()
+    {
+        $anotherMailbox = $this->createMailbox();
+        $messages = [1, 2, 3];
+
+        $this->assertSame(0, $anotherMailbox->count());
+        $this->assertSame(3, $this->mailbox->count());
+        $this->mailbox->copy($messages, $anotherMailbox);
+
+        $this->assertSame(3, $anotherMailbox->count());
+        $this->assertSame(3, $this->mailbox->count());
+
+        // test failing bulk copy - try to move to a non-existent mailbox
+        $this->getConnection()->deleteMailbox($anotherMailbox);
+        $this->expectException(MessageMoveException::class);
+        $this->mailbox->copy($messages, $anotherMailbox);
+    }
 }


### PR DESCRIPTION
Implement a new bulk move feature to allow moving messages between mailboxes at once.

This is able to work with an array of message ids or a MessageIterator. For compatibility with the other bulk commands, there also is the possibility to directly input a list of comma separated message ids as a string.

Fixes #305