### PR TITLE
Remove final keyword from selected classes.

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -12,7 +12,7 @@ use Ddeboer\Imap\Exception\MailboxDoesNotExistException;
 /**
  * A connection to an IMAP server that is authenticated for a user.
  */
-final class Connection implements ConnectionInterface
+class Connection implements ConnectionInterface
 {
     /**
      * @var ImapResourceInterface

--- a/src/ImapResource.php
+++ b/src/ImapResource.php
@@ -10,7 +10,7 @@ use Ddeboer\Imap\Exception\ReopenMailboxException;
 /**
  * An imap resource stream.
  */
-final class ImapResource implements ImapResourceInterface
+class ImapResource implements ImapResourceInterface
 {
     /**
      * @var resource

--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -14,7 +14,7 @@ use Ddeboer\Imap\Search\LogicalOperator\All;
 /**
  * An IMAP mailbox (commonly referred to as a 'folder').
  */
-final class Mailbox implements MailboxInterface
+class Mailbox implements MailboxInterface
 {
     /**
      * @var ImapResourceInterface

--- a/src/Message.php
+++ b/src/Message.php
@@ -13,7 +13,7 @@ use Ddeboer\Imap\Exception\MessageStructureException;
 /**
  * An IMAP message (e-mail).
  */
-final class Message extends Message\AbstractMessage implements MessageInterface
+class Message extends Message\AbstractMessage implements MessageInterface
 {
     /**
      * @var null|Message\Headers

--- a/src/MessageIterator.php
+++ b/src/MessageIterator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Ddeboer\Imap;
 
-final class MessageIterator extends \ArrayIterator implements MessageIteratorInterface
+class MessageIterator extends \ArrayIterator implements MessageIteratorInterface
 {
     /**
      * @var ImapResourceInterface

--- a/src/SearchExpression.php
+++ b/src/SearchExpression.php
@@ -9,7 +9,7 @@ use Ddeboer\Imap\Search\ConditionInterface;
 /**
  * Defines a search expression that can be used to look up email messages.
  */
-final class SearchExpression implements ConditionInterface
+class SearchExpression implements ConditionInterface
 {
     /**
      * The conditions that together represent the expression.

--- a/src/Server.php
+++ b/src/Server.php
@@ -9,7 +9,7 @@ use Ddeboer\Imap\Exception\AuthenticationFailedException;
 /**
  * An IMAP server.
  */
-final class Server implements ServerInterface
+class Server implements ServerInterface
 {
     /**
      * @var string Internet domain name or bracketed IP address of server


### PR DESCRIPTION
Remove 'final' keyword on selected classed. This allows for easier mocking while writing unit tests. It also makes it possible to extend these classes and add custom functionality.  