### PR TITLE
Adds getters in the server to resolve issue #327.

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -108,22 +108,22 @@ final class Server implements ServerInterface
         return new Connection(new ImapResource($resource), $connection);
     }
 
-    public function getHostname() : string
+    public function getHostname(): string
     {
         return $this->hostname;
     }
 
-    public function getPort() : string
+    public function getPort(): string
     {
         return $this->port;
     }
 
-    public function getFlags() : string
+    public function getFlags(): string
     {
         return $this->flags;
     }
 
-    public function getParameters() : array
+    public function getParameters(): array
     {
         return $this->parameters;
     }

--- a/src/Server.php
+++ b/src/Server.php
@@ -11,6 +11,9 @@ use Ddeboer\Imap\Exception\AuthenticationFailedException;
  */
 final class Server implements ServerInterface
 {
+    const DEFAULT_PORT = '993';
+    const DEFAULT_FLAGS = '/imap/ssl/validate-cert';
+
     /**
      * @var string Internet domain name or bracketed IP address of server
      */
@@ -42,8 +45,8 @@ final class Server implements ServerInterface
      */
     public function __construct(
         string $hostname,
-        string $port = '993',
-        string $flags = '/imap/ssl/validate-cert',
+        string $port = self::DEFAULT_PORT,
+        string $flags = self::DEFAULT_FLAGS,
         array $parameters = []
     ) {
         if (!\function_exists('imap_open')) {
@@ -103,6 +106,26 @@ final class Server implements ServerInterface
         \imap_alerts();
 
         return new Connection(new ImapResource($resource), $connection);
+    }
+
+    public function getHostname() : string
+    {
+        return $this->hostname;
+    }
+
+    public function getPort() : string
+    {
+        return $this->port;
+    }
+
+    public function getFlags() : string
+    {
+        return $this->flags;
+    }
+
+    public function getParameters() : array
+    {
+        return $this->parameters;
     }
 
     /**

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -22,8 +22,8 @@ final class ServerTest extends AbstractTest
     {
         $this->hostname = 'dummy-imap-server.example.com';
         $this->port = '5555'; // TODO: Should't the port be numeric? http://php.net/manual/en/function.imap-open.php states that the port is a number.
-        $this->flags = ( $this->flagsProvider() )[ 'properly formatted' ][ 0 ];
-        $this->parameters = [ 'a' => 'b' ];
+        $this->flags = ($this->flagsProvider())['properly formatted'][0];
+        $this->parameters = ['a' => 'b'];
     }
 
     public function testValidConnection()
@@ -60,43 +60,43 @@ final class ServerTest extends AbstractTest
     {
         $server = new Server($this->hostname);
 
-        $this->assertEquals($this->hostname, $server->getHostname());
+        $this->assertSame($this->hostname, $server->getHostname());
     }
 
     public function testGetPortReturnsConstructorPortWhenPortIsStated()
     {
         $server = new Server($this->hostname, $this->port);
 
-        $this->assertEquals($this->port, $server->getPort());
+        $this->assertSame($this->port, $server->getPort());
     }
 
     public function testGetPortReturnsDefaultPortWhenPortIsNotStated()
     {
         $server = new Server($this->hostname);
 
-        $this->assertEquals($server::DEFAULT_PORT, $server->getPort());
+        $this->assertSame($server::DEFAULT_PORT, $server->getPort());
     }
 
     /** @dataProvider flagsProvider */
-    public function testGetFlagsReturnsConstructorFlagsWhenFlagsAreStated( string $flags, string $expectedFlags )
+    public function testGetFlagsReturnsConstructorFlagsWhenFlagsAreStated(string $flags, string $expectedFlags)
     {
         $server = new Server($this->hostname, $this->port, $flags);
 
-        $this->assertEquals($expectedFlags, $server->getFlags());
+        $this->assertSame($expectedFlags, $server->getFlags());
     }
 
     public function testGetFlagsReturnsDefaultFlagsWhenFlagsAreNotStated()
     {
         $server = new Server($this->hostname);
 
-        $this->assertEquals($server::DEFAULT_FLAGS, $server->getFlags());
+        $this->assertSame($server::DEFAULT_FLAGS, $server->getFlags());
     }
 
     public function testGetParametersReturnsConstructorParamatersWhenParametersAreStated()
     {
         $server = new Server($this->hostname, $this->port, $this->flags, $this->parameters);
 
-        $this->assertEquals($this->parameters, $server->getParameters());
+        $this->assertSame($this->parameters, $server->getParameters());
     }
 
     public function testGetParametersReturnsEmptyArrayWhenParametersAreNotStated()
@@ -108,13 +108,13 @@ final class ServerTest extends AbstractTest
 
     // Data providers
 
-    public function flagsProvider() : array
+    public function flagsProvider(): array
     {
         return [
-            'properly formatted' => [ '/silly/flags', '/silly/flags' ],
-            'without leading slash' => [ 'silly/flags', '/silly/flags' ],
-            'single slash' => [ '/', '/' ],
-            'empty string' => [ '', '' ],
+            'properly formatted' => ['/silly/flags', '/silly/flags'],
+            'without leading slash' => ['silly/flags', '/silly/flags'],
+            'single slash' => ['/', '/'],
+            'empty string' => ['', ''],
         ];
     }
 }

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -13,6 +13,19 @@ use Ddeboer\Imap\Server;
  */
 final class ServerTest extends AbstractTest
 {
+    private $hostname;
+    private $port;
+    private $flags;
+    private $parameters;
+
+    protected function setUp()
+    {
+        $this->hostname = 'dummy-imap-server.example.com';
+        $this->port = '5555'; // TODO: Should't the port be numeric? http://php.net/manual/en/function.imap-open.php states that the port is a number.
+        $this->flags = ( $this->flagsProvider() )[ 'properly formatted' ][ 0 ];
+        $this->parameters = [ 'a' => 'b' ];
+    }
+
     public function testValidConnection()
     {
         $connection = $this->getConnection();
@@ -41,5 +54,67 @@ final class ServerTest extends AbstractTest
         $server = new Server(\getenv('IMAP_SERVER_NAME'), '', self::IMAP_FLAGS);
 
         $this->assertInstanceOf(ConnectionInterface::class, $server->authenticate(\getenv('IMAP_USERNAME'), \getenv('IMAP_PASSWORD')));
+    }
+
+    public function testGetHostname()
+    {
+        $server = new Server($this->hostname);
+
+        $this->assertEquals($this->hostname, $server->getHostname());
+    }
+
+    public function testGetPortReturnsConstructorPortWhenPortIsStated()
+    {
+        $server = new Server($this->hostname, $this->port);
+
+        $this->assertEquals($this->port, $server->getPort());
+    }
+
+    public function testGetPortReturnsDefaultPortWhenPortIsNotStated()
+    {
+        $server = new Server($this->hostname);
+
+        $this->assertEquals($server::DEFAULT_PORT, $server->getPort());
+    }
+
+    /** @dataProvider flagsProvider */
+    public function testGetFlagsReturnsConstructorFlagsWhenFlagsAreStated( string $flags, string $expectedFlags )
+    {
+        $server = new Server($this->hostname, $this->port, $flags);
+
+        $this->assertEquals($expectedFlags, $server->getFlags());
+    }
+
+    public function testGetFlagsReturnsDefaultFlagsWhenFlagsAreNotStated()
+    {
+        $server = new Server($this->hostname);
+
+        $this->assertEquals($server::DEFAULT_FLAGS, $server->getFlags());
+    }
+
+    public function testGetParametersReturnsConstructorParamatersWhenParametersAreStated()
+    {
+        $server = new Server($this->hostname, $this->port, $this->flags, $this->parameters);
+
+        $this->assertEquals($this->parameters, $server->getParameters());
+    }
+
+    public function testGetParametersReturnsEmptyArrayWhenParametersAreNotStated()
+    {
+        $server = new Server($this->hostname);
+
+        $this->assertCount(0, $server->getParameters());
+    }
+
+    // Data providers
+
+    public function flagsProvider() : array
+    {
+        return [
+            'properly formatted' => [ '/silly/flags', '/silly/flags' ],
+            'without leading slash' => [ 'silly/flags', '/silly/flags' ],
+            'single slash' => [ '/', '/' ],
+            'empty string' => [ '', '' ],
+        ];
     }
 }


### PR DESCRIPTION
Run the unit tests with:

    vendor/bin/phpunit tests/ServerTest.php --filter testGet

all the new tests are named beginning with `testGet` and none of the failing tests use that pattern.

    PHPUnit 6.5.7 by Sebastian Bergmann and contributors.
    
    Runtime:       PHP 7.0.25-0ubuntu0.16.04.1 with Xdebug 2.5.4
    Configuration: /files/custom_www/hello-trip/tmp/imap/phpunit.xml.dist
    
    ..........                                                        10 / 10 (100%)
    
    Time: 46 ms, Memory: 4.00MB
    
    OK (10 tests, 10 assertions)

The tests are structured like this:

* The `getHostname()` is trivial.
* The `getPort()` and `getParameters()` do test when it is stated and when not in the constructor.
* The `getFlags()` tests also several of the cases of the logic in the constructor.
