### PR TITLE
Add charset for imap_search or imap_sort

### DIFF
--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -150,7 +150,7 @@ final class Mailbox implements MailboxInterface
      *
      * @return MessageIteratorInterface
      */
-    public function getMessages(ConditionInterface $search = null, int $sortCriteria = null, bool $descending = false): MessageIteratorInterface
+    public function getMessages(ConditionInterface $search = null, int $sortCriteria = null, bool $descending = false, string $charset = null): MessageIteratorInterface
     {
         if (null === $search) {
             $search = new All();
@@ -162,9 +162,9 @@ final class Mailbox implements MailboxInterface
         \imap_errors();
 
         if (null !== $sortCriteria) {
-            $messageNumbers = \imap_sort($this->resource->getStream(), $sortCriteria, $descending ? 1 : 0, \SE_UID, $query);
+            $messageNumbers = \imap_sort($this->resource->getStream(), $sortCriteria, $descending ? 1 : 0, \SE_UID, $query, $charset);
         } else {
-            $messageNumbers = \imap_search($this->resource->getStream(), $query, \SE_UID);
+            $messageNumbers = \imap_search($this->resource->getStream(), $query, \SE_UID, $charset);
         }
         if (false === $messageNumbers) {
             if (false !== \imap_last_error()) {

--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -150,7 +150,7 @@ final class Mailbox implements MailboxInterface
      *
      * @return MessageIteratorInterface
      */
-    public function getMessages(ConditionInterface $search = null, int $sortCriteria = null, bool $descending = false, string $charset = null): MessageIteratorInterface
+    public function getMessages(ConditionInterface $search = null, int $sortCriteria = null, bool $descending = false, string $charset = 'utf-8'): MessageIteratorInterface
     {
         if (null === $search) {
             $search = new All();


### PR DESCRIPTION
For example you need to search a message by the subject with a keyword "Bestellbestätigung". So you need to provide a charset "utf-8" to imap_search, to make correct a searching. But method "getMessages" does not have a charset parameter.