### PR TITLE
Added the number search condition

### DIFF
--- a/src/Search/Number.php
+++ b/src/Search/Number.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ddeboer\Imap\Search;
+
+/**
+ * Represents a number range condition. Number is formally known as UID.
+ */
+abstract class Number implements ConditionInterface
+{
+    /**
+     * The minimum accepted message number (null means unlimited).
+     *
+     * @var int|null
+     */
+    private $minNumber;
+
+    /**
+     * The maximum accepted message number (null means unlimited).
+     *
+     * @var int|null
+     */
+    private $maxNumber;
+
+    /**
+     * Constructor.
+     *
+     * @param int|null $minNumber the minimum accepted message number (null means unlimited)
+     * @param int|null $maxNumber the maximum accepted message number (null means unlimited)
+     */
+    public function __construct(int $minNumber = null, int $maxNumber = null)
+    {
+        $this->minNumber = $minNumber;
+        $this->maxNumber = $maxNumber;
+    }
+
+    /**
+     * Converts the condition to a string that can be sent to the IMAP server.
+     *
+     * @return string
+     */
+    final public function toString(): string
+    {
+        return \sprintf('UID %s:%s', $this->minNumber ?? '*', $this->maxNumber ?? '*');
+    }
+}

--- a/src/Search/Number.php
+++ b/src/Search/Number.php
@@ -12,24 +12,24 @@ final class Number implements ConditionInterface
     /**
      * The minimum accepted message number (null means unlimited).
      *
-     * @var int|null
+     * @var null|int
      */
     private $minNumber;
 
     /**
      * The maximum accepted message number (null means unlimited).
      *
-     * @var int|null
+     * @var null|int
      */
     private $maxNumber;
 
     /**
      * Constructor.
      *
-     * @param int|null $minNumber the minimum accepted message number (null means unlimited)
-     * @param int|null $maxNumber the maximum accepted message number (null means unlimited)
+     * @param null|int $minNumber the minimum accepted message number (null means unlimited)
+     * @param null|int $maxNumber the maximum accepted message number (null means unlimited)
      */
-    public function __construct(int $minNumber = null, int $maxNumber = null)
+    final public function __construct(int $minNumber = null, int $maxNumber = null)
     {
         $this->minNumber = $minNumber;
         $this->maxNumber = $maxNumber;
@@ -42,6 +42,6 @@ final class Number implements ConditionInterface
      */
     final public function toString(): string
     {
-        return \sprintf('UID %s:%s', $this->minNumber ?? '*', $this->maxNumber ?? '*');
+        return \sprintf('UID "%s:%s"', $this->minNumber ?? '*', $this->maxNumber ?? '*');
     }
 }

--- a/src/Search/Number.php
+++ b/src/Search/Number.php
@@ -7,7 +7,7 @@ namespace Ddeboer\Imap\Search;
 /**
  * Represents a number range condition. Number is formally known as UID.
  */
-abstract class Number implements ConditionInterface
+final class Number implements ConditionInterface
 {
     /**
      * The minimum accepted message number (null means unlimited).

--- a/tests/MailboxSearchTest.php
+++ b/tests/MailboxSearchTest.php
@@ -30,6 +30,7 @@ use Ddeboer\Imap\SearchExpression;
  * @covers \Ddeboer\Imap\Search\Flag\Unseen
  * @covers \Ddeboer\Imap\Search\LogicalOperator\All
  * @covers \Ddeboer\Imap\Search\LogicalOperator\OrConditions
+ * @covers \Ddeboer\Imap\Search\Number
  * @covers \Ddeboer\Imap\Search\RawExpression
  * @covers \Ddeboer\Imap\Search\State\Deleted
  * @covers \Ddeboer\Imap\Search\State\NewMessage
@@ -103,6 +104,7 @@ final class MailboxSearchTest extends AbstractTest
             new Search\Flag\Unanswered(),
             new Search\Flag\Unflagged(),
             new Search\Flag\Unseen(),
+            new Search\Number(15670, 16829),
             new Search\State\Deleted(),
             new Search\State\NewMessage(),
             new Search\State\Old(),

--- a/tests/Search/NumberTest.php
+++ b/tests/Search/NumberTest.php
@@ -16,20 +16,20 @@ final class NumberTest extends AbstractTest
     {
         $condition = new Number(5, 100);
 
-        $this->assertSame('UID 5:100');
+        $this->assertSame('UID "5:100"', $condition->toString());
     }
 
     public function testWithoutMinimum()
     {
         $condition = new Number(null, 50);
 
-        $this->assertSame('UID *:50');
+        $this->assertSame('UID "*:50"', $condition->toString());
     }
 
     public function testWithoutMaximum()
     {
         $condition = new Number(3820);
 
-        $this->assertSame('UID 3820:*');
+        $this->assertSame('UID "3820:*"', $condition->toString());
     }
 }

--- a/tests/Search/NumberTest.php
+++ b/tests/Search/NumberTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ddeboer\Imap\Tests\Search;
+
+use Ddeboer\Imap\Search\Number;
+use Ddeboer\Imap\Tests\AbstractTest;
+
+/**
+ * @covers \Ddeboer\Imap\Search\Number
+ */
+final class NumberTest extends AbstractTest
+{
+    public function testWithMinimumAndMaximum()
+    {
+        $condition = new Number(5, 100);
+
+        $this->assertSame('UID 5:100');
+    }
+
+    public function testWithoutMinimum()
+    {
+        $condition = new Number(null, 50);
+
+        $this->assertSame('UID *:50');
+    }
+
+    public function testWithoutMaximum()
+    {
+        $condition = new Number(3820);
+
+        $this->assertSame('UID 3820:*');
+    }
+}


### PR DESCRIPTION
I've added a condition to filter messages by their numbers (formally known as UIDs).

It can be useful when you need to synchronise messages between an IMAP inbox and a local database. You can save the last received message number and later fetch only the messages that are newer than the received message.

```php
use Ddeboer\Imap\Search\Number;

$lastReceivedMessageNumber = /* get a number from somewhere, e.g. database */;
$search = new Number($lastReceivedMessageNumber + 1);
$messages = $mailbox->getMessages($search);
```