### PR TITLE
In dates, replace UT with UTC

### DIFF
--- a/src/Message/AbstractMessage.php
+++ b/src/Message/AbstractMessage.php
@@ -120,6 +120,7 @@ abstract class AbstractMessage extends AbstractPart
         $alteredValue = \str_replace(',', '', $alteredValue);
         $alteredValue = \preg_replace('/^[a-zA-Z]+ ?/', '', $alteredValue);
         $alteredValue = \preg_replace('/ +\(.*\)/', '', $alteredValue);
+        $alteredValue = \preg_replace('/\bUT\b/', 'UTC', $alteredValue);
         if (0 === \preg_match('/\d\d:\d\d:\d\d.* [\+\-]\d\d:?\d\d/', $alteredValue)) {
             $alteredValue .= ' +0000';
         }


### PR DESCRIPTION
A date like "12 Feb 2008 06:35:05 UT +0000" throws an exception. This replaces "UT" with "UTC".