### PR TITLE
Gracefully handle possible non-array return value of imap_getmailboxes

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -6,6 +6,7 @@ namespace Ddeboer\Imap;
 
 use Ddeboer\Imap\Exception\CreateMailboxException;
 use Ddeboer\Imap\Exception\DeleteMailboxException;
+use Ddeboer\Imap\Exception\ImapGetmailboxesException;
 use Ddeboer\Imap\Exception\InvalidResourceException;
 use Ddeboer\Imap\Exception\MailboxDoesNotExistException;
 
@@ -202,6 +203,10 @@ final class Connection implements ConnectionInterface
 
         $this->mailboxNames = [];
         $mailboxesInfo = \imap_getmailboxes($this->resource->getStream(), $this->server, '*');
+        if (!\is_array($mailboxesInfo)) {
+            throw new ImapGetmailboxesException('imap_getmailboxes failed');
+        }
+
         foreach ($mailboxesInfo as $mailboxInfo) {
             $name = \mb_convert_encoding(\str_replace($this->server, '', $mailboxInfo->name), 'UTF-8', 'UTF7-IMAP');
             $this->mailboxNames[$name] = $mailboxInfo;

--- a/src/Exception/ImapGetmailboxesException.php
+++ b/src/Exception/ImapGetmailboxesException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ddeboer\Imap\Exception;
+
+final class ImapGetmailboxesException extends AbstractException
+{
+}


### PR DESCRIPTION
Reference: https://github.com/ddeboer/imap/issues/134

@robertodormepoco please can you checkout my branch [imap_getmailboxes_non_array](https://github.com/Slamdunk/imap/tree/imap_getmailboxes_non_array) and report here the full exception error message, so I can better document what happens?