### PR TITLE
Get messages by UID sequence

### DIFF
--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -179,7 +179,7 @@ final class Mailbox implements MailboxInterface
     }
 
     /**
-     * Get message iterator for a sequence
+     * Get message iterator for a sequence.
      *
      * @param string $sequence Message numbers
      *
@@ -190,15 +190,16 @@ final class Mailbox implements MailboxInterface
         \imap_errors();
 
         $overview = \imap_fetch_overview($this->resource->getStream(), $sequence, FT_UID);
-        if (false === $overview) {
+        if (empty($overview)) {
             if (false !== \imap_last_error()) {
                 throw new InvalidSearchCriteriaException(\sprintf('Invalid sequence [%s]', $sequence));
             }
 
             $messageNumbers = [];
         } else {
-            $messageNumbers = array_column($overview, 'uid');
+            $messageNumbers = \array_column($overview, 'uid');
         }
+
         return new MessageIterator($this->resource, $messageNumbers);
     }
 

--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -179,6 +179,30 @@ final class Mailbox implements MailboxInterface
     }
 
     /**
+     * Get message iterator for a sequence
+     *
+     * @param string $sequence Message numbers
+     *
+     * @return MessageIteratorInterface
+     */
+    public function getMessageSequence(string $sequence): MessageIteratorInterface
+    {
+        \imap_errors();
+
+        $overview = \imap_fetch_overview($this->resource->getStream(), $sequence, FT_UID);
+        if (false === $overview) {
+            if (false !== \imap_last_error()) {
+                throw new InvalidSearchCriteriaException(\sprintf('Invalid sequence [%s]', $sequence));
+            }
+
+            $messageNumbers = [];
+        } else {
+            $messageNumbers = array_column($overview, 'uid');
+        }
+        return new MessageIterator($this->resource, $messageNumbers);
+    }
+
+    /**
      * Get a message by message number.
      *
      * @param int $number Message number

--- a/src/MailboxInterface.php
+++ b/src/MailboxInterface.php
@@ -86,7 +86,7 @@ interface MailboxInterface extends \Countable, \IteratorAggregate
     public function getMessages(ConditionInterface $search = null, int $sortCriteria = null, bool $descending = false): MessageIteratorInterface;
 
     /**
-     * Get message iterator for a sequence
+     * Get message iterator for a sequence.
      *
      * @param string $sequence Message numbers
      *

--- a/src/MailboxInterface.php
+++ b/src/MailboxInterface.php
@@ -86,6 +86,15 @@ interface MailboxInterface extends \Countable, \IteratorAggregate
     public function getMessages(ConditionInterface $search = null, int $sortCriteria = null, bool $descending = false): MessageIteratorInterface;
 
     /**
+     * Get message iterator for a sequence
+     *
+     * @param string $sequence Message numbers
+     *
+     * @return MessageIteratorInterface
+     */
+    public function getMessageSequence(string $sequence): MessageIteratorInterface;
+
+    /**
      * Get a message by message number.
      *
      * @param int $number Message number

--- a/tests/MailboxTest.php
+++ b/tests/MailboxTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ddeboer\Imap\Tests;
 
 use DateTimeImmutable;
+use Ddeboer\Imap\Exception\InvalidSearchCriteriaException;
 use Ddeboer\Imap\Exception\MessageCopyException;
 use Ddeboer\Imap\Exception\MessageDoesNotExistException;
 use Ddeboer\Imap\Exception\MessageMoveException;
@@ -78,6 +79,18 @@ final class MailboxTest extends AbstractTest
             ++$inc;
         }
         $this->assertSame(3, $inc);
+
+        $inc = 0;
+        foreach ($this->mailbox->getMessageSequence('1:2') as $message) {
+            ++$inc;
+        }
+        $this->assertSame(2, $inc);
+    }
+
+    public function testGetMessageSequenceThrowsException()
+    {
+        $this->expectException(InvalidSearchCriteriaException::class);
+        $this->mailbox->getMessageSequence('-1:x');
     }
 
     public function testGetMessageThrowsException()

--- a/tests/MailboxTest.php
+++ b/tests/MailboxTest.php
@@ -84,7 +84,13 @@ final class MailboxTest extends AbstractTest
         foreach ($this->mailbox->getMessageSequence('1:2') as $message) {
             ++$inc;
         }
+
         $this->assertSame(2, $inc);
+        $inc = 0;
+        foreach ($this->mailbox->getMessageSequence('99998:99999') as $message) {
+            ++$inc;
+        }
+        $this->assertSame(0, $inc);
     }
 
     public function testGetMessageSequenceThrowsException()

--- a/tests/MailboxTest.php
+++ b/tests/MailboxTest.php
@@ -71,6 +71,15 @@ final class MailboxTest extends AbstractTest
         $this->assertSame(3, $aggregateIteratorMethodInc);
     }
 
+    public function testGetMessageSequence()
+    {
+        $inc = 0;
+        foreach ($this->mailbox->getMessageSequence('1:*') as $message) {
+            ++$inc;
+        }
+        $this->assertSame(3, $inc);
+    }
+
     public function testGetMessageThrowsException()
     {
         $message = $this->mailbox->getMessage(999);


### PR DESCRIPTION
I needed to get Messages based on an UID sequence. imap_search and imap_sort don't support that, apparently you have to use imap_fetch_overview.

I added a method to the Mailbox object that lets you get a MessageIterator based on a sequence of ids.

This allows you to store the id of the last message you read an then later read only messages with a higher id than that.

`foreach ( $mailbox->getMessageSequence($lastImported . ':*') as $message ) {`