### PR TITLE
Adding an undelete() message method

### DIFF
--- a/src/Exception/MessageUndeleteException.php
+++ b/src/Exception/MessageUndeleteException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ddeboer\Imap\Exception;
+
+final class MessageUndeleteException extends AbstractException
+{
+}

--- a/src/Message.php
+++ b/src/Message.php
@@ -315,6 +315,20 @@ final class Message extends Message\AbstractMessage implements MessageInterface
     }
 
     /**
+     * Undelete message.
+     *
+     * @throws MessageUndeleteException
+     */
+    public function undelete(): void
+    {
+        // 'deleted' header changed, force to reload headers, would be better to set deleted flag to false on header
+        $this->clearHeaders();
+        if (!\imap_undelete($this->resource->getStream(), $this->getNumber(), \FT_UID)) {
+            throw new MessageUndeleteException(\sprintf('Message "%s" cannot be undeleted', $this->getNumber()));
+        }
+    }
+
+    /**
      * Set Flag Message.
      *
      * @param string $flag \Seen, \Answered, \Flagged, \Deleted, and \Draft

--- a/src/Message.php
+++ b/src/Message.php
@@ -10,6 +10,7 @@ use Ddeboer\Imap\Exception\MessageDeleteException;
 use Ddeboer\Imap\Exception\MessageDoesNotExistException;
 use Ddeboer\Imap\Exception\MessageMoveException;
 use Ddeboer\Imap\Exception\MessageStructureException;
+use Ddeboer\Imap\Exception\MessageUndeleteException;
 
 /**
  * An IMAP message (e-mail).

--- a/src/MessageInterface.php
+++ b/src/MessageInterface.php
@@ -101,6 +101,11 @@ interface MessageInterface extends Message\BasicMessageInterface
     public function delete(): void;
 
     /**
+     * Undelete message.
+     */
+    public function undelete(): void;
+
+    /**
      * Set Flag Message.
      *
      * @param string $flag \Seen, \Answered, \Flagged, \Deleted, and \Draft

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -359,6 +359,24 @@ final class MessageTest extends AbstractTest
         }
     }
 
+    public function testUndelete()
+    {
+        $this->createTestMessage($this->mailbox, 'Message A');
+        $this->createTestMessage($this->mailbox, 'Message B');
+        $this->createTestMessage($this->mailbox, 'Message C');
+
+        $message = $this->mailbox->getMessage(3);
+        $message->delete();
+        $message->undelete();
+        $this->assertFalse($message->isDeleted());
+        $this->getConnection()->expunge();
+
+        $this->assertCount(3, $this->mailbox);
+        $this->assertSame('Message A', $this->mailbox->getMessage(1)->getSubject());
+        $this->assertSame('Message B', $this->mailbox->getMessage(2)->getSubject());
+        $this->assertSame('Message C', $this->mailbox->getMessage(3)->getSubject());
+    }
+
     public function testMove()
     {
         $mailboxOne = $this->createMailbox();


### PR DESCRIPTION
This PR aims to add an `undelete()` method on `Ddeboer\Imap\Message` as a wrapper for builtin PHP `imap_undelete()` function.