### PR TITLE
Remove GBK -> X-GBK Alias and add X-GBK -> GBK

### DIFF
--- a/src/Message/Transcoder.php
+++ b/src/Message/Transcoder.php
@@ -122,7 +122,7 @@ final class Transcoder
         'elot_928' => 'ISO-8859-7',
         'gb_2312' => 'GB2312',
         'gb_2312-80' => 'GB2312',
-        'gbk' => 'x-gbk',
+        'x-gbk' => 'gbk',
         'greek' => 'ISO-8859-7',
         'greek8' => 'ISO-8859-7',
         'hebrew' => 'ISO-8859-8',

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -1032,4 +1032,13 @@ final class MessageTest extends AbstractTest
 
         $messages->current();
     }
+
+    public function testGbkCharsetDecoding()
+    {
+        $this->mailbox->addMessage($this->getFixture('gbk_charset'));
+
+        $message = $this->mailbox->getMessage(1);
+
+        $this->assertSame('Hi', trim($message->getDecodedContent()));
+    }
 }

--- a/tests/fixtures/gbk_charset.eml
+++ b/tests/fixtures/gbk_charset.eml
@@ -1,0 +1,9 @@
+From: from@there.com
+To: to@here.com
+Subject: Nuu
+Date: Wed, 13 Sep 2017 13:05:45 +0200
+Content-Type: text/plain;
+	charset="X-GBK"
+Content-Transfer-Encoding: quoted-printable
+
+Hi


### PR DESCRIPTION
I have an Issue with decoding a message in GBK encoding, becouse it transform to X-GBK that not supported by iconv PHP function. 

I saw this doc https://encoding.spec.whatwg.org/#encodings and this one https://dxr.mozilla.org/mozilla-central/source/dom/encoding/labelsencodings.properties and in the second document X-GBK should be transformed to GBK. 

related issue #395 