### PR TITLE
Add new ResourceCheckFailureException to handle imap_check() false

### DIFF
--- a/src/Exception/ResourceCheckFailureException.php
+++ b/src/Exception/ResourceCheckFailureException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ddeboer\Imap\Exception;
+
+final class ResourceCheckFailureException extends AbstractException
+{
+
+}

--- a/src/Server.php
+++ b/src/Server.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ddeboer\Imap;
 
 use Ddeboer\Imap\Exception\AuthenticationFailedException;
+use Ddeboer\Imap\Exception\ResourceCheckFailureException;
 
 /**
  * An IMAP server.
@@ -111,6 +112,11 @@ final class Server implements ServerInterface
         }
 
         $check = \imap_check($resource);
+
+        if (false === $check) {
+            throw new ResourceCheckFailureException('Resource check failure');
+        }
+
         $mailbox = $check->Mailbox;
         $connection = \substr($mailbox, 0, \strpos($mailbox, '}') + 1);
 


### PR DESCRIPTION
Sometimes imap_check() can return false insted of Object with Mailbox field and in this case I have an error log like this:

`Notice: Trying to get property 'Mailbox' of non-object in vendor/ddeboer/imap/src/Server.php on line 114`
`Fatal error: Uncaught TypeError: strpos() expects parameter 1 to be string, null given in vendor/ddeboer/imap/src/Server.php:115`

I suppose to add new ResourceCheckFailureException if imap_check return false. 

PS: I don't known how to get FALSE from imap_check in tests, Could you help me with tests?

Thanks!