### PR TITLE
Added default charset for imap_search() in getMessages method

### DIFF
--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -150,7 +150,7 @@ final class Mailbox implements MailboxInterface
      *
      * @return MessageIteratorInterface
      */
-    public function getMessages(ConditionInterface $search = null, int $sortCriteria = null, bool $descending = false): MessageIteratorInterface
+    public function getMessages(ConditionInterface $search = null, int $sortCriteria = null, bool $descending = false, string $searchCharset = 'UTF-8'): MessageIteratorInterface
     {
         if (null === $search) {
             $search = new All();
@@ -164,7 +164,7 @@ final class Mailbox implements MailboxInterface
         if (null !== $sortCriteria) {
             $messageNumbers = \imap_sort($this->resource->getStream(), $sortCriteria, $descending ? 1 : 0, \SE_UID, $query);
         } else {
-            $messageNumbers = \imap_search($this->resource->getStream(), $query, \SE_UID);
+            $messageNumbers = \imap_search($this->resource->getStream(), $query, \SE_UID, $searchCharset);
         }
         if (false === $messageNumbers) {
             if (false !== \imap_last_error()) {


### PR DESCRIPTION
When I trying to search messages with conditions on Cyrillic symbols I get an error:
> Invalid search criteria [BODY "облако"]
> imap_alerts (0):
> imap_errors (1):
> - [BADCHARSET] UID SEARCH Unsupported text encoding. sc=6LdKu0aQaW21_011321_25j