### PR TITLE
Handle message/rfc822 when content-disposition is missing

### DIFF
--- a/src/Message/AbstractPart.php
+++ b/src/Message/AbstractPart.php
@@ -583,7 +583,7 @@ abstract class AbstractPart implements PartInterface
         if (self::SUBTYPE_RFC822 === \strtoupper($part->subtype)) {
             return true;
         }
-        
+
         return false;
     }
 }

--- a/src/Message/AbstractPart.php
+++ b/src/Message/AbstractPart.php
@@ -580,7 +580,7 @@ abstract class AbstractPart implements PartInterface
         }
          */
 
-        if (\strtoupper($part->subtype) === self::SUBTYPE_RFC822) {
+        if (self::SUBTYPE_RFC822 === \strtoupper($part->subtype)) {
             return true;
         }
         

--- a/src/Message/AbstractPart.php
+++ b/src/Message/AbstractPart.php
@@ -580,6 +580,10 @@ abstract class AbstractPart implements PartInterface
         }
          */
 
+        if (\strtoupper($part->subtype) === self::SUBTYPE_RFC822) {
+            return true;
+        }
+        
         return false;
     }
 }

--- a/src/Message/PartInterface.php
+++ b/src/Message/PartInterface.php
@@ -29,6 +29,7 @@ interface PartInterface extends \RecursiveIterator
 
     public const SUBTYPE_PLAIN  = 'PLAIN';
     public const SUBTYPE_HTML   = 'HTML';
+    public const SUBTYPE_RFC822 = 'RFC822';
 
     /**
      * Get message number (from headers).

--- a/tests/EmbeddedMessageTest.php
+++ b/tests/EmbeddedMessageTest.php
@@ -134,6 +134,11 @@ final class EmbeddedMessageTest extends AbstractTest
         $attachment = \next($attachments);
         static::assertTrue($attachment->isEmbeddedMessage());
 
+        $embeddedMessage = $attachment->getEmbeddedMessage();
+        static::assertSame('embedded_message_subject', $embeddedMessage->getSubject());
+        static::assertNotEmpty($embeddedMessage->getBodyText());
+        static::assertNotEmpty($embeddedMessage->getBodyHtml());
+        
         $attachment = \next($attachments);
         static::assertNotEmpty($attachment->getContent());
         static::assertSame('file1.xlsx', $attachment->getFilename());

--- a/tests/EmbeddedMessageTest.php
+++ b/tests/EmbeddedMessageTest.php
@@ -116,4 +116,43 @@ final class EmbeddedMessageTest extends AbstractTest
 
         static::assertCount(0, $thirdEmbeddedMessage->getAttachments());
     }
+    
+    public function testEmbeddedMessageWithoutContentDisposition()
+    {
+        $mailbox = $this->createMailbox();
+        $raw     = $this->getFixture('embedded_email_without_content_disposition');
+        $mailbox->addMessage($raw);
+
+        $message     = $mailbox->getMessage(1);
+        $attachments = $message->getAttachments();
+        static::assertCount(6, $attachments);
+
+        $attachment = \current($attachments);
+        static::assertNotEmpty($attachment->getContent());
+        static::assertSame('file.jpg', $attachment->getFilename());
+
+        $attachment = \next($attachments);
+        static::assertTrue($attachment->isEmbeddedMessage());
+
+        $embeddedMessage = $attachment->getEmbeddedMessage();
+        static::assertSame('embedded_message_subject', $embeddedMessage->getSubject());
+        static::assertNotEmpty($embeddedMessage->getBodyText());
+        static::assertNotEmpty($embeddedMessage->getBodyText());
+
+        $attachment = \next($attachments);
+        static::assertNotEmpty($attachment->getContent());
+        static::assertSame('file1.xlsx', $attachment->getFilename());
+
+        $attachment = \next($attachments);
+        static::assertNotEmpty($attachment->getContent());
+        static::assertSame('file2.xlsx', $attachment->getFilename());
+
+        $attachment = \next($attachments);
+        static::assertNotEmpty($attachment->getContent());
+        static::assertSame('file3.xlsx', $attachment->getFilename());
+
+        $attachment = \next($attachments);
+        static::assertNotEmpty($attachment->getContent());
+        static::assertSame('file4.zip', $attachment->getFilename());
+    }
 }

--- a/tests/EmbeddedMessageTest.php
+++ b/tests/EmbeddedMessageTest.php
@@ -116,7 +116,7 @@ final class EmbeddedMessageTest extends AbstractTest
 
         static::assertCount(0, $thirdEmbeddedMessage->getAttachments());
     }
-    
+
     public function testEmbeddedMessageWithoutContentDisposition()
     {
         $mailbox = $this->createMailbox();
@@ -133,11 +133,6 @@ final class EmbeddedMessageTest extends AbstractTest
 
         $attachment = \next($attachments);
         static::assertTrue($attachment->isEmbeddedMessage());
-
-        $embeddedMessage = $attachment->getEmbeddedMessage();
-        static::assertSame('embedded_message_subject', $embeddedMessage->getSubject());
-        static::assertNotEmpty($embeddedMessage->getBodyText());
-        static::assertNotEmpty($embeddedMessage->getBodyText());
 
         $attachment = \next($attachments);
         static::assertNotEmpty($attachment->getContent());

--- a/tests/EmbeddedMessageTest.php
+++ b/tests/EmbeddedMessageTest.php
@@ -138,7 +138,7 @@ final class EmbeddedMessageTest extends AbstractTest
         static::assertSame('embedded_message_subject', $embeddedMessage->getSubject());
         static::assertNotEmpty($embeddedMessage->getBodyText());
         static::assertNotEmpty($embeddedMessage->getBodyHtml());
-        
+
         $attachment = \next($attachments);
         static::assertNotEmpty($attachment->getContent());
         static::assertSame('file1.xlsx', $attachment->getFilename());

--- a/tests/fixtures/embedded_email_without_content_disposition.eml
+++ b/tests/fixtures/embedded_email_without_content_disposition.eml
@@ -1,0 +1,141 @@
+Return-Path: demo@cerstor.cz
+Received: from webmail.my-office.cz (localhost [127.0.0.1])
+	by keira.cofis.cz
+	; Fri, 29 Jan 2016 14:25:40 +0100
+From: demo@cerstor.cz
+To: demo@cerstor.cz
+Date: Fri, 5 Apr 2019 13:48:50 +0200
+Subject: Subject
+Message-ID: <AC39946EBF5C034B87BABD5343E96979012671D9F7E4@VM002.cerk.cc>
+Accept-Language: pl-PL, nl-NL
+Content-Type: multipart/mixed;
+	boundary="_008_AC39946EBF5C034B87BABD5343E96979012671D9F7E4VM002emonsn_"
+MIME-Version: 1.0
+
+--_008_AC39946EBF5C034B87BABD5343E96979012671D9F7E4VM002emonsn_
+Content-Type: multipart/related;
+	boundary="_007_AC39946EBF5C034B87BABD5343E96979012671D9F7E4VM002emonsn_";
+	type="multipart/alternative"
+
+--_007_AC39946EBF5C034B87BABD5343E96979012671D9F7E4VM002emonsn_
+Content-Type: multipart/alternative;
+	boundary="_000_AC39946EBF5C034B87BABD5343E96979012671D9F7E4VM002emonsn_"
+
+--_000_AC39946EBF5C034B87BABD5343E96979012671D9F7E4VM002emonsn_
+Content-Type: text/plain; charset="iso-8859-2"
+Content-Transfer-Encoding: quoted-printable
+
+TexT
+
+[cid:file.jpg]
+
+--_000_AC39946EBF5C034B87BABD5343E96979012671D9F7E4VM002emonsn_
+Content-Type: text/html; charset="iso-8859-2"
+Content-Transfer-Encoding: quoted-printable
+
+<html><p>TexT</p></html>=
+
+--_000_AC39946EBF5C034B87BABD5343E96979012671D9F7E4VM002emonsn_--
+
+--_007_AC39946EBF5C034B87BABD5343E96979012671D9F7E4VM002emonsn_
+Content-Type: image/jpeg; name=
+	"file.jpg"
+Content-Description: file.jpg
+Content-Disposition: inline; filename=
+	"file.jpg";
+	size=54558; creation-date="Fri, 05 Apr 2019 11:48:58 GMT";
+	modification-date="Fri, 05 Apr 2019 11:48:58 GMT"
+Content-ID: <file.jpg>
+Content-Transfer-Encoding: base64
+
+iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==
+
+--_007_AC39946EBF5C034B87BABD5343E96979012671D9F7E4VM002emonsn_--
+
+--_008_AC39946EBF5C034B87BABD5343E96979012671D9F7E4VM002emonsn_
+Content-Type: message/rfc822
+
+Received: from webmail.my-office.cz (localhost [127.0.0.1])
+	by keira.cofis.cz
+	; Fri, 29 Jan 2016 14:25:40 +0100
+From: demo@cerstor.cz
+To: demo@cerstor.cz
+Date: Fri, 5 Apr 2019 12:10:49 +0200
+Subject: embedded_message_subject
+Message-ID: <AC39946EBF5C034B87BABD5343E96979012671D40E38@VM002.cerk.cc>
+Accept-Language: pl-PL, nl-NL
+Content-Language: pl-PL
+Content-Type: multipart/mixed;
+	boundary="_005_AC39946EBF5C034B87BABD5343E96979012671D40E38VM002emonsn_"
+MIME-Version: 1.0
+
+--_005_AC39946EBF5C034B87BABD5343E96979012671D40E38VM002emonsn_
+Content-Type: multipart/alternative;
+	boundary="_000_AC39946EBF5C034B87BABD5343E96979012671D40E38VM002emonsn_"
+
+--_000_AC39946EBF5C034B87BABD5343E96979012671D40E38VM002emonsn_
+Content-Type: text/plain; charset="iso-8859-2"
+Content-Transfer-Encoding: quoted-printable
+
+some txt
+
+
+
+
+
+--_000_AC39946EBF5C034B87BABD5343E96979012671D40E38VM002emonsn_
+Content-Type: text/html; charset="iso-8859-2"
+Content-Transfer-Encoding: quoted-printable
+
+<html>
+ <p>some txt</p>
+</html>
+
+--_000_AC39946EBF5C034B87BABD5343E96979012671D40E38VM002emonsn_--
+
+--_005_AC39946EBF5C034B87BABD5343E96979012671D40E38VM002emonsn_
+Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;
+	name="file1.xlsx"
+Content-Description: file1.xlsx
+Content-Disposition: attachment; filename="file1.xlsx"; size=29;
+	creation-date="Fri, 05 Apr 2019 10:06:01 GMT";
+	modification-date="Fri, 05 Apr 2019 10:10:49 GMT"
+Content-Transfer-Encoding: base64
+
+IHRoaXMgaXMgY29udGVudCBvZiB0ZXN0IGZpbGU=
+
+--_005_AC39946EBF5C034B87BABD5343E96979012671D40E38VM002emonsn_
+Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;
+	name="file2.xlsx"
+Content-Description: file2
+Content-Disposition: attachment; filename="file2.xlsx"; size=29;
+	creation-date="Fri, 05 Apr 2019 10:10:19 GMT";
+	modification-date="Wed, 03 Apr 2019 11:04:32 GMT"
+Content-Transfer-Encoding: base64
+
+IHRoaXMgaXMgY29udGVudCBvZiB0ZXN0IGZpbGU=
+
+--_005_AC39946EBF5C034B87BABD5343E96979012671D40E38VM002emonsn_--
+
+--_008_AC39946EBF5C034B87BABD5343E96979012671D9F7E4VM002emonsn_
+Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;
+	name="file3.xlsx"
+Content-Description: file3.xlsx
+Content-Disposition: attachment; filename="file3.xlsx";
+	size=90672; creation-date="Fri, 05 Apr 2019 11:46:30 GMT";
+	modification-date="Thu, 28 Mar 2019 08:07:58 GMT"
+Content-Transfer-Encoding: base64
+
+IHRoaXMgaXMgY29udGVudCBvZiB0ZXN0IGZpbGU=
+
+--_008_AC39946EBF5C034B87BABD5343E96979012671D9F7E4VM002emonsn_
+Content-Type: application/x-zip-compressed; name="file4.zip"
+Content-Description: file4.zip
+Content-Disposition: attachment; filename="file4.zip"; size=29;
+	creation-date="Fri, 05 Apr 2019 11:48:45 GMT";
+	modification-date="Fri, 05 Apr 2019 11:35:24 GMT"
+Content-Transfer-Encoding: base64
+
+IHRoaXMgaXMgY29udGVudCBvZiB0ZXN0IGZpbGU=
+
+--_008_AC39946EBF5C034B87BABD5343E96979012671D9F7E4VM002emonsn_--


### PR DESCRIPTION
Handle forwarded messages, when `Content-Disposition` is missing, but `Content-Type: message/rfc822`
is present.

Is necessary to mark this part as attachment, because of `multipart/mixed` section in parts.

Yes it's real scenario.

**BEFORE FIX:**
parts number will have bad counting: 2.1.2 (when 1 is a `multipart/mixed`), when try fetch body for 2.1.2 part, imap sending `NULL`. 

**AFTER FIX:**
parts numbered correctly 2.2 and you cant fetch body for part 2.2


**HOW TO REPRODUCE ?**

Create eml, with forwarded message as attachment, and remove `Content-Disposition`