### PR TITLE
Clear the last used mailbox cache when closing a connection

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -69,6 +69,7 @@ final class Connection implements ConnectionInterface
      */
     public function close(int $flag = 0): bool
     {
+        $this->resource->clearLastMailboxUsedCache();
         return \imap_close($this->resource->getStream(), $flag);
     }
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -70,6 +70,7 @@ final class Connection implements ConnectionInterface
     public function close(int $flag = 0): bool
     {
         $this->resource->clearLastMailboxUsedCache();
+
         return \imap_close($this->resource->getStream(), $flag);
     }
 

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -159,4 +159,22 @@ final class ConnectionTest extends AbstractTest
 
         static::assertArrayHasKey($number, $mailboxes);
     }
+
+    public function testMailboxSelectionAfterReconnect(): void
+    {
+        $connection  = $this->createConnection();
+        $mailbox     = $this->createMailbox($connection);
+        $mailboxName = $mailbox->getName();
+        $this->createTestMessage($mailbox, 'Reconnect test');
+
+        $connection->close();
+
+        $connection = $this->createConnection();
+        $mailbox    = $connection->getMailbox($mailboxName);
+
+        // This fails if we haven't properly reselected the mailbox
+        static::assertSame('Reconnect test', $mailbox->getMessages()->current()->getSubject());
+
+        $connection->close();
+    }
 }


### PR DESCRIPTION
Running getMessages() on a mailbox after closing the connection and opening a new one to the same server does not work correctly in all cases. It breaks when the same mailbox was used/selected before closing the previous connection (unless it happens to be the inbox).