### PR TITLE
MailboxIterface: Typehint to interface instead of implementation

### DIFF
--- a/src/MailboxInterface.php
+++ b/src/MailboxInterface.php
@@ -45,16 +45,16 @@ interface MailboxInterface extends \Countable, \IteratorAggregate
     /**
      * Bulk Set Flag for Messages.
      *
-     * @param string                       $flag    \Seen, \Answered, \Flagged, \Deleted, and \Draft
-     * @param array|MessageIterator|string $numbers Message numbers
+     * @param string                                $flag    \Seen, \Answered, \Flagged, \Deleted, and \Draft
+     * @param array|MessageIteratorInterface|string $numbers Message numbers
      */
     public function setFlag(string $flag, $numbers): bool;
 
     /**
      * Bulk Clear Flag for Messages.
      *
-     * @param string                       $flag    \Seen, \Answered, \Flagged, \Deleted, and \Draft
-     * @param array|MessageIterator|string $numbers Message numbers
+     * @param string                                $flag    \Seen, \Answered, \Flagged, \Deleted, and \Draft
+     * @param array|MessageIteratorInterface|string $numbers Message numbers
      */
     public function clearFlag(string $flag, $numbers): bool;
 
@@ -97,8 +97,8 @@ interface MailboxInterface extends \Countable, \IteratorAggregate
     /**
      * Bulk move messages.
      *
-     * @param array|MessageIterator|string $numbers Message numbers
-     * @param MailboxInterface             $mailbox Destination Mailbox to move the messages to
+     * @param array|MessageIteratorInterface|string $numbers Message numbers
+     * @param MailboxInterface                      $mailbox Destination Mailbox to move the messages to
      *
      * @throws \Ddeboer\Imap\Exception\MessageMoveException
      */
@@ -107,8 +107,8 @@ interface MailboxInterface extends \Countable, \IteratorAggregate
     /**
      * Bulk copy messages.
      *
-     * @param array|MessageIterator|string $numbers Message numbers
-     * @param MailboxInterface             $mailbox Destination Mailbox to copy the messages to
+     * @param array|MessageIteratorInterface|string $numbers Message numbers
+     * @param MailboxInterface                       $mailbox Destination Mailbox to copy the messages to
      *
      * @throws \Ddeboer\Imap\Exception\MessageCopyException
      */


### PR DESCRIPTION
Prefer `MessageIteratorInterface` instead of `MessageIterator`.

This should not be a breaking change as `MessageIterator implements MessageIteratorInterface`