### PR TITLE
Subtype not always present

### DIFF
--- a/src/Message/AbstractPart.php
+++ b/src/Message/AbstractPart.php
@@ -471,7 +471,7 @@ abstract class AbstractPart implements PartInterface
 
         $this->type = self::$typesMap[$this->structure->type] ?? self::TYPE_UNKNOWN;
 
-        // In our context, \ENCOTHER is as useful as an uknown encoding
+        // In our context, \ENCOTHER is as useful as an unknown encoding
         $this->encoding = self::$encodingsMap[$this->structure->encoding] ?? self::ENCODING_UNKNOWN;
         $this->subtype  = $this->structure->subtype;
 

--- a/src/Message/AbstractPart.php
+++ b/src/Message/AbstractPart.php
@@ -473,7 +473,9 @@ abstract class AbstractPart implements PartInterface
 
         // In our context, \ENCOTHER is as useful as an unknown encoding
         $this->encoding = self::$encodingsMap[$this->structure->encoding] ?? self::ENCODING_UNKNOWN;
-        $this->subtype  = $this->structure->subtype;
+        if (isset($this->structure->subtype)) {
+            $this->subtype = $this->structure->subtype;
+        }
 
         if (isset($this->structure->bytes)) {
             $this->bytes = $this->structure->bytes;


### PR DESCRIPTION
A MIME message doesn't always have a subtype
- a well-formed message part should have it
- alas, we also need to handle not-so-well-formed ones
- this leads to `Notice: Undefined property: stdClass::$subtype`, which is enough to trip up some applications.