### PR TITLE
Fix: Outlook date format

### DIFF
--- a/src/Message/AbstractMessage.php
+++ b/src/Message/AbstractMessage.php
@@ -113,6 +113,7 @@ abstract class AbstractMessage extends AbstractPart
         $alteredValue = \str_replace(',', '', $alteredValue);
         $alteredValue = (string) \preg_replace('/^[a-zA-Z]+ ?/', '', $alteredValue);
         $alteredValue = (string) \preg_replace('/\(.*\)/', '', $alteredValue);
+        $alteredValue = (string) \preg_replace('/\<.*\>/', '', $alteredValue);
         $alteredValue = (string) \preg_replace('/\bUT\b/', 'UTC', $alteredValue);
         if (0 === \preg_match('/\d\d:\d\d:\d\d.* [\+\-]\d\d:?\d\d/', $alteredValue)) {
             $alteredValue .= ' +0000';

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -608,6 +608,7 @@ final class MessageTest extends AbstractTest
             ['2014-09-15T05:25:04+0000', 'Mon, 15 09 2014 05:25:04'], // Non compliant to RFC2822#section-3.3
             ['2014-09-30T10:50:58+0200', 'Tue, 30 Sep 2014 10:50:58 +0200 (added by postmaster@redacted.it) '],
             ['2014-09-30T10:50:58+0200', ' (added by postmaster@redacted.it)  Tue, 30 Sep 2014 10:50:58 +0200'],
+            ['2020-10-27T10:25:58+0000', 'Tue, 27 Oct 2020 10:25:58 +0000 <AM8PR08MB565014C82DF69A14167D12829D160@AM8PR08MB5650.eurprd08.prod.outlook.com>'],
         ];
     }
 


### PR DESCRIPTION
**Ddeboer\Imap\Exception\InvalidDateHeaderException**

```
Invalid Date header found: "Tue, 27 Oct 2020 10:25:58 +0000 <AM8PR08MB56censored12829D160@AM8censored50.eurprd08.prod.outlook.com>"
imap_alerts (0):
imap_errors (0):
```

```
  at C:\xampp\htdocs\Modular-App\vendor\ddeboer\imap\src\Message\AbstractMessage.php:127
    123|
    124|         try {
    125|             $date = new \DateTimeImmutable($alteredValue);
    126|         } catch (\Throwable $ex) {
  > 127|             throw new InvalidDateHeaderException(\sprintf('Invalid Date header found: "%s"', $dateHeader), 0, $ex);
    128|         }
    129|
    130|         return $date;
    131|     }
```