### PR TITLE
fix: can use the internalDate when options is NULL

### DIFF
--- a/src/Mailbox.php
+++ b/src/Mailbox.php
@@ -183,12 +183,11 @@ final class Mailbox implements MailboxInterface
             $this->resource->getStream(),
             $this->getFullEncodedName(),
             $message,
+            $options
         ];
-        if (null !== $options) {
-            $arguments[] = $options;
-            if (null !== $internalDate) {
-                $arguments[] = $internalDate->format('d-M-Y H:i:s O');
-            }
+
+        if (null !== $internalDate) {
+            $arguments[] = $internalDate->format('d-M-Y H:i:s O');
         }
 
         return \imap_append(...$arguments);


### PR DESCRIPTION
When ``$options`` is set to NULL, ``internalDate`` is not send to ``imap_append``