### PR TITLE
Add Countable Interface to MessageIteratorInterface.

### DIFF
--- a/src/MessageIteratorInterface.php
+++ b/src/MessageIteratorInterface.php
@@ -9,7 +9,7 @@ use Ddeboer\Imap\Message\PartInterface;
 /**
  * @extends \Iterator<MessageInterface>
  */
-interface MessageIteratorInterface extends \Iterator
+interface MessageIteratorInterface extends \Iterator, \Countable
 {
     /**
      * Get current message.


### PR DESCRIPTION
Since all classes which implement this interface inherit from \ArrayIterator the needed implementation is already done. This change allows count(MailboxInterface::getMessages).