### PR TITLE
Initialize address as null. Previously if an email with no recipient …

### DIFF
--- a/src/Message/EmailAddress.php
+++ b/src/Message/EmailAddress.php
@@ -19,6 +19,7 @@ final class EmailAddress
         $this->mailbox  = $mailbox;
         $this->hostname = $hostname;
         $this->name     = $name;
+        $this->address  = null;
 
         if (null !== $hostname) {
             $this->address = $mailbox . '@' . $hostname;


### PR DESCRIPTION
Right now if an email with undisclosed recipients is received, calling getAddress will throw an Error 'Typed property Ddeboer\Imap\Message\EmailAddress::$address must not be accessed before initialization' as initialization of the address property only occurs when a non-null hostname is passed in.  

(Some more info on this error
https://madewithlove.com/blog/software-engineering/typed-property-must-not-be-accessed-before-initialization/ )

Change is to initialize address as null before the hostname check. Thanks