### PR TITLE
Require PHP 8.0.1 for imap_msgno() bugfix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^7.4 || ^8.0.1",
         "ext-iconv": "*",
         "ext-imap": "*",
         "ext-mbstring": "*"


### PR DESCRIPTION
Fix #485.

This was caused by PHP bug #80438, which was fixed in 8.0.1.