### PR TITLE
Fix resource check for PHP 8.1 which returns an object

### DIFF
--- a/src/ImapResource.php
+++ b/src/ImapResource.php
@@ -32,7 +32,7 @@ final class ImapResource implements ImapResourceInterface
 
     public function getStream()
     {
-        if (false === \is_resource($this->resource) || 'imap' !== \get_resource_type($this->resource)) {
+        if (false === $this->resource || !($this->resource instanceof \IMAP\Connection)) {
             throw new InvalidResourceException('Supplied resource is not a valid imap resource');
         }
 


### PR DESCRIPTION
Example of how to fix #525 - PHP 8.1 compatibility. The [official upgrade guide](https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.resource2object) says, "Return value checks using is_resource() should be replaced with checks for false." I did an extra check for instance of Imap\Connection which might not be necessary.

I haven't tested but I'm assuming this will break compatibility with PHP < 8.1. Maybe it is better to do a PHP version check first - if PHP 8.1 then check false, otherwise check resource.

Let me know how to handle and I can re-submit. 
