### PR TITLE
added a method to allow to connect to a shared mailbox for office365

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -21,6 +21,7 @@ final class Server implements ServerInterface
     private array $parameters;
     private int $options;
     private int $retries;
+    private ?string $accessMailbox = null;
 
     /**
      * Constructor.
@@ -74,7 +75,7 @@ final class Server implements ServerInterface
 
         $resource = \imap_open(
             $this->getServerString(),
-            $username,
+            $username.(! is_null($this->accessMailbox) ? '/'.$this->accessMailbox : ''),
             $password,
             $this->options,
             $this->retries,
@@ -109,6 +110,18 @@ final class Server implements ServerInterface
         \imap_alerts();
 
         return new Connection(new ImapResource($resource), $connection);
+    }
+
+    /**
+     * Access a (shared) mailbox (for office365) directly while using the credentials of another user (using the authenticate method).
+     *
+     * @param string $mailbox
+     * @return static
+     */
+    public function forMailbox(string $mailbox): static
+    {
+        $this->accessMailbox = $mailbox;
+        return $this;
     }
 
     /**

--- a/src/ServerInterface.php
+++ b/src/ServerInterface.php
@@ -16,4 +16,12 @@ interface ServerInterface
      * @param string $password Password
      */
     public function authenticate(string $username, string $password): ConnectionInterface;
+
+    /**
+     * Access a (shared) mailbox (for office365) directly while using the credentials of another user (using the authenticate method).
+     *
+     * @param string $mailbox
+     * @return static
+     */
+    public function forMailbox(string $mailbox): static;
 }

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -59,4 +59,16 @@ final class ServerTest extends AbstractTest
         static::assertStringNotContainsString('inbox', $mailbox);
         static::assertStringContainsString('no_mailbox', $mailbox);
     }
+
+    public function testSetMailbox(): void
+    {
+        $server = new Server((string) \getenv('IMAP_SERVER_NAME'), (string) \getenv('IMAP_SERVER_PORT'), self::IMAP_FLAGS, [], \OP_HALFOPEN);
+        $server->forMailbox('random@mailbox.com');
+
+        $reflection = new \ReflectionClass($server);
+        $reflection_property = $reflection->getProperty('accessMailbox');
+        $reflection_property->setAccessible(true);
+
+        static::assertSame('random@mailbox.com', $reflection_property->getValue($server));
+    }
 }


### PR DESCRIPTION
This pull requests adds the method `forMailbox()` on the `serverInterface`.

This allows use to make a connection to a shared mailbox in office365 using:
```php
$server = new Server('outlook.office365.com');
$connection = $server->forMailbox('sharedmailbox@mail.com')
                     ->authenticate('ownmailbox@mail.com', 'Password');
```

This also addresses issue #393 partially as this is the implementation for connection with <ownaccount>/<sharedaccount> variant.