### PR TITLE
Fix: Prevent restore cache on closing connection

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -50,9 +50,11 @@ final class Connection implements ConnectionInterface
 
     public function close(int $flag = 0): bool
     {
+        $stream = $this->resource->getStream();
+
         $this->resource->clearLastMailboxUsedCache();
 
-        return \imap_close($this->resource->getStream(), $flag);
+        return \imap_close($stream, $flag);
     }
 
     public function getQuota(string $root = 'INBOX'): array


### PR DESCRIPTION
This semantic is wrong:

https://github.com/ddeboer/imap/blob/c8e26a01ba4367fc4ae9536633c462d92cbca8d8/src/Connection.php#L51-L56

because calling of `$this->resource->getStream()` is refill cache cleared on previous line.

This PR is change call order to prevent refill cache with reference to closed resource.
