### PR TITLE
Messages: Add ability to native save mail content to file

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -133,6 +133,14 @@ final class Message extends Message\AbstractMessage implements MessageInterface
         return $this->rawMessage;
     }
 
+    /**
+     * @param resource|string $file the path to the saved file as a string, or a valid file descriptor
+     */
+    public function saveRawMessage($file): void
+    {
+        $this->doSaveContent($file, '');
+    }
+
     public function getHeaders(): Message\Headers
     {
         if (null === $this->headers) {

--- a/src/Message/AbstractPart.php
+++ b/src/Message/AbstractPart.php
@@ -256,6 +256,26 @@ abstract class AbstractPart implements PartInterface
         return $return;
     }
 
+    /**
+     * Save raw message content to file.
+     *
+     * @param resource|string $file the path to the saved file as a string, or a valid file descriptor
+     */
+    final protected function doSaveContent($file, string $partNumber): void
+    {
+        $return = \imap_savebody(
+            $this->resource->getStream(),
+            $file,
+            $this->getNumber(),
+            $partNumber,
+            \FT_UID | \FT_PEEK
+        );
+
+        if (false === $return) {
+            throw new ImapFetchbodyException('imap_savebody failed');
+        }
+    }
+
     final public function getParts(): array
     {
         $this->lazyParseStructure();

--- a/src/Message/BasicMessageInterface.php
+++ b/src/Message/BasicMessageInterface.php
@@ -19,6 +19,13 @@ interface BasicMessageInterface extends PartInterface
     public function getRawMessage(): string;
 
     /**
+     * Save the raw message, including all headers, parts, etc. unencoded and unparsed to file.
+     *
+     * @param resource|string $file the path to the saved file as a string, or a valid file descriptor
+     */
+    public function saveRawMessage($file): void;
+
+    /**
      * Get message headers.
      */
     public function getHeaders(): Headers;

--- a/src/Message/EmbeddedMessage.php
+++ b/src/Message/EmbeddedMessage.php
@@ -39,6 +39,14 @@ final class EmbeddedMessage extends AbstractMessage implements EmbeddedMessageIn
     }
 
     /**
+     * @param resource|string $file the path to the saved file as a string, or a valid file descriptor
+     */
+    public function saveRawMessage($file): void
+    {
+        $this->doSaveContent($file, $this->getPartNumber());
+    }
+
+    /**
      * Get content part number.
      */
     protected function getContentPartNumber(): string

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -748,6 +748,45 @@ final class MessageTest extends AbstractTest
         static::assertSame($fixture, $message->getRawMessage());
     }
 
+    public function testSaveFileRawMessage(): void
+    {
+        $fixture = $this->getFixture('structured_with_attachment');
+        $this->mailbox->addMessage($fixture);
+
+        $message = $this->mailbox->getMessage(1);
+
+        $filename = \tempnam(\sys_get_temp_dir(), 'testSaveFileRawMessage');
+        if (false === $filename) {
+            static::fail('Unable to create temporary file');
+        }
+
+        $message->saveRawMessage($filename);
+
+        static::assertSame($fixture, \file_get_contents($filename));
+
+        \unlink($filename);
+    }
+
+    public function testSaveResourceRawMessage(): void
+    {
+        $fixture = $this->getFixture('structured_with_attachment');
+        $this->mailbox->addMessage($fixture);
+
+        $message = $this->mailbox->getMessage(1);
+
+        $file = \fopen('php://temp', 'w+');
+        if (false === $file) {
+            static::fail('Unable to create temporary file stream');
+        }
+
+        $message->saveRawMessage($file);
+        \fseek($file, 0);
+
+        static::assertSame($fixture, \stream_get_contents($file));
+
+        \fclose($file);
+    }
+
     public function testAttachmentOnlyEmail(): void
     {
         $fixture = $this->getFixture('mail_that_is_attachment');

--- a/tests/fixtures/embedded_email_without_content_disposition-embedded.eml
+++ b/tests/fixtures/embedded_email_without_content_disposition-embedded.eml
@@ -1,0 +1,61 @@
+Received: from webmail.my-office.cz (localhost [127.0.0.1])
+	by keira.cofis.cz
+	; Fri, 29 Jan 2016 14:25:40 +0100
+From: demo@cerstor.cz
+To: demo@cerstor.cz
+Date: Fri, 5 Apr 2019 12:10:49 +0200
+Subject: embedded_message_subject
+Message-ID: <AC39946EBF5C034B87BABD5343E96979012671D40E38@VM002.cerk.cc>
+Accept-Language: pl-PL, nl-NL
+Content-Language: pl-PL
+Content-Type: multipart/mixed;
+	boundary="_005_AC39946EBF5C034B87BABD5343E96979012671D40E38VM002emonsn_"
+MIME-Version: 1.0
+
+--_005_AC39946EBF5C034B87BABD5343E96979012671D40E38VM002emonsn_
+Content-Type: multipart/alternative;
+	boundary="_000_AC39946EBF5C034B87BABD5343E96979012671D40E38VM002emonsn_"
+
+--_000_AC39946EBF5C034B87BABD5343E96979012671D40E38VM002emonsn_
+Content-Type: text/plain; charset="iso-8859-2"
+Content-Transfer-Encoding: quoted-printable
+
+some txt
+
+
+
+
+
+--_000_AC39946EBF5C034B87BABD5343E96979012671D40E38VM002emonsn_
+Content-Type: text/html; charset="iso-8859-2"
+Content-Transfer-Encoding: quoted-printable
+
+<html>
+ <p>some txt</p>
+</html>
+
+--_000_AC39946EBF5C034B87BABD5343E96979012671D40E38VM002emonsn_--
+
+--_005_AC39946EBF5C034B87BABD5343E96979012671D40E38VM002emonsn_
+Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;
+	name="file1.xlsx"
+Content-Description: file1.xlsx
+Content-Disposition: attachment; filename="file1.xlsx"; size=29;
+	creation-date="Fri, 05 Apr 2019 10:06:01 GMT";
+	modification-date="Fri, 05 Apr 2019 10:10:49 GMT"
+Content-Transfer-Encoding: base64
+
+IHRoaXMgaXMgY29udGVudCBvZiB0ZXN0IGZpbGU=
+
+--_005_AC39946EBF5C034B87BABD5343E96979012671D40E38VM002emonsn_
+Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;
+	name="file2.xlsx"
+Content-Description: file2
+Content-Disposition: attachment; filename="file2.xlsx"; size=29;
+	creation-date="Fri, 05 Apr 2019 10:10:19 GMT";
+	modification-date="Wed, 03 Apr 2019 11:04:32 GMT"
+Content-Transfer-Encoding: base64
+
+IHRoaXMgaXMgY29udGVudCBvZiB0ZXN0IGZpbGU=
+
+--_005_AC39946EBF5C034B87BABD5343E96979012671D40E38VM002emonsn_--


### PR DESCRIPTION
PR is adding ability to store raw Message (or their parts) to file directly via native [`imap_savebody()`](https://www.php.net/manual/en/function.imap-savebody.php) function.

Direct handling I/O is much more effective than fetch Message Body as string and than save it. Some messages may have huge size, it may waste process memory.

Example how to simple store Message content file: 
```php
$filename = 'message-content.eml';
$message->saveRawMessage($filename);
```

## Streams
The `imap_savebody()` function supports Streams too, this provides the ability to connect elements with pipes for effective manipulating with mail content. 

Example how to simple store Message content to **compressed** file with single atomic operation: 
```php
$file = gzopen('message-content.eml.gz', 'wb');
$message->saveRawMessage($file);
gzclose($file);
```

- [x] Add tests.