### PR TITLE
Add `subscribeMailbox` to `Connection`

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -10,6 +10,7 @@ use Ddeboer\Imap\Exception\ImapGetmailboxesException;
 use Ddeboer\Imap\Exception\ImapNumMsgException;
 use Ddeboer\Imap\Exception\ImapQuotaException;
 use Ddeboer\Imap\Exception\MailboxDoesNotExistException;
+use Ddeboer\Imap\Exception\SubscribeMailboxException;
 
 /**
  * A connection to an IMAP server that is authenticated for a user.
@@ -175,6 +176,13 @@ final class Connection implements ConnectionInterface
             \assert(\is_string($name));
 
             $this->mailboxNames[$name] = $mailboxInfo;
+        }
+    }
+
+    public function subscribeMailbox(string $name): void
+    {
+        if (false === \imap_subscribe($this->resource->getStream(), $this->server . \mb_convert_encoding($name, 'UTF7-IMAP', 'UTF-8'))) {
+            throw new SubscribeMailboxException(\sprintf('Can not subscribe to "%s" mailbox at "%s"', $name, $this->server));
         }
     }
 }

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -7,6 +7,7 @@ namespace Ddeboer\Imap;
 use Ddeboer\Imap\Exception\CreateMailboxException;
 use Ddeboer\Imap\Exception\DeleteMailboxException;
 use Ddeboer\Imap\Exception\MailboxDoesNotExistException;
+use Ddeboer\Imap\Exception\SubscribeMailboxException;
 
 /**
  * A connection to an IMAP server that is authenticated for a user.
@@ -76,4 +77,11 @@ interface ConnectionInterface extends \Countable
      * @throws DeleteMailboxException
      */
     public function deleteMailbox(MailboxInterface $mailbox): void;
+
+    /**
+     * Subscribe to mailbox.
+     *
+     * @throws SubscribeMailboxException
+     */
+    public function subscribeMailbox(string $name): void;
 }

--- a/src/Exception/SubscribeMailboxException.php
+++ b/src/Exception/SubscribeMailboxException.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ddeboer\Imap\Exception;
+
+final class SubscribeMailboxException extends AbstractException {}

--- a/src/Exception/SubscribeMailboxException.php
+++ b/src/Exception/SubscribeMailboxException.php
@@ -4,4 +4,6 @@ declare(strict_types=1);
 
 namespace Ddeboer\Imap\Exception;
 
-final class SubscribeMailboxException extends AbstractException {}
+final class SubscribeMailboxException extends AbstractException
+{
+}

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -8,6 +8,7 @@ use Ddeboer\Imap\Connection;
 use Ddeboer\Imap\Exception\CreateMailboxException;
 use Ddeboer\Imap\Exception\DeleteMailboxException;
 use Ddeboer\Imap\Exception\MailboxDoesNotExistException;
+use Ddeboer\Imap\Exception\SubscribeMailboxException;
 use Ddeboer\Imap\ImapResource;
 use Ddeboer\Imap\Mailbox;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -154,5 +155,19 @@ final class ConnectionTest extends AbstractTestCase
         self::assertSame('Reconnect test', $mailbox->getMessages()->current()->getSubject());
 
         $connection->close();
+    }
+
+    public function testSubscribeMailbox(): void
+    {
+        $connection = $this->getConnection();
+
+        $name    = \uniqid('test_');
+        $mailbox = $connection->createMailbox($name);
+        $connection->subscribeMailbox($name);
+
+        $connection->deleteMailbox($mailbox);
+
+        $this->expectException(SubscribeMailboxException::class);
+        $connection->subscribeMailbox($name);
     }
 }


### PR DESCRIPTION
So just ran into the same 'issue' as here: #448 and thought why not create a PR for it: first PR on this repo so hope it is okay or otherwise would love some feedback on what to change / improve.

I have added subscribeMailbox as a separate method and not as part of the createMailbox method as I am not sure if all IMAP servers support subscribing.
Having it as a separate function gives more flexibility.