### PR TITLE
Remove final keyword from certain classes/methods to improve extensibility

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -14,7 +14,7 @@ use Ddeboer\Imap\Exception\MessageStructureException;
 /**
  * An IMAP message (e-mail).
  */
-final class Message extends Message\AbstractMessage implements MessageInterface
+class Message extends Message\AbstractMessage implements MessageInterface
 {
     private bool $messageNumberVerified = false;
     private int $imapMsgNo              = 0;

--- a/src/Message/AbstractPart.php
+++ b/src/Message/AbstractPart.php
@@ -239,7 +239,7 @@ abstract class AbstractPart implements PartInterface
     /**
      * Get raw message content.
      */
-    final protected function doGetContent(string $partNumber): string
+    protected function doGetContent(string $partNumber): string
     {
         $return = \imap_fetchbody(
             $this->resource->getStream(),
@@ -260,7 +260,7 @@ abstract class AbstractPart implements PartInterface
      *
      * @param resource|string $file the path to the saved file as a string, or a valid file descriptor
      */
-    final protected function doSaveContent($file, string $partNumber): void
+    protected function doSaveContent($file, string $partNumber): void
     {
         $return = \imap_savebody(
             $this->resource->getStream(),

--- a/src/Message/EmbeddedMessage.php
+++ b/src/Message/EmbeddedMessage.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Ddeboer\Imap\Message;
 
-final class EmbeddedMessage extends AbstractMessage implements EmbeddedMessageInterface
+class EmbeddedMessage extends AbstractMessage implements EmbeddedMessageInterface
 {
-    private ?Headers $headers   = null;
-    private ?string $rawHeaders = null;
-    private ?string $rawMessage = null;
+    protected ?Headers $headers   = null;
+    protected ?string $rawHeaders = null;
+    protected ?string $rawMessage = null;
 
     public function getHeaders(): Headers
     {

--- a/src/Message/Headers.php
+++ b/src/Message/Headers.php
@@ -6,7 +6,7 @@ namespace Ddeboer\Imap\Message;
 
 use Ddeboer\Imap\Exception\UnsupportedCharsetException;
 
-final class Headers extends Parameters
+class Headers extends Parameters
 {
     public function __construct(\stdClass $headers)
     {

--- a/src/Message/Parameters.php
+++ b/src/Message/Parameters.php
@@ -40,7 +40,7 @@ class Parameters extends \ArrayIterator
         return $this[$key] ?? null;
     }
 
-    final protected function decode(string $value): string
+    protected function decode(string $value): string
     {
         $parts = \imap_mime_header_decode($value);
         if (!\is_array($parts)) {


### PR DESCRIPTION
Hi,

This PR removes the final keyword from a few classes and methods to improve extensibility. The discussion in [issue #265](https://github.com/ddeboer/imap/issues/265#issuecomment-2614082128) highlights a valid concern: the current final restrictions limit customization and extension of the library. For example: testing without an imap server.

No breaking changes, as this only relaxes restrictions without modifying existing behavior.

Please let me know if this is desirable, as I prefer not to maintain a fork for this